### PR TITLE
Fix #23232: Don't use world-writable cache directory anymore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/bin/brew
 !/share/man/man1/brew.1
 .DS_Store
+/Library/Cache
 /Library/LinkedKegs
 /Library/PinnedKegs
 /Library/Taps

--- a/Library/Contributions/manpages/brew.1.md
+++ b/Library/Contributions/manpages/brew.1.md
@@ -483,8 +483,7 @@ can take several different forms:
   * HOMEBREW\_CACHE:
     If set, instructs Homebrew to use the given directory as the download cache.
 
-    *Default:* `~/Library/Caches/Homebrew` if it exists; otherwise,
-    `/Library/Caches/Homebrew`.
+    *Default:* `$(brew --repository)/Library/Cache`
 
   * HOMEBREW\_CURL\_VERBOSE:
     If set, Homebrew will pass `--verbose` when invoking `curl`(1).

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -28,100 +28,15 @@ HOMEBREW_CONTRIB = HOMEBREW_REPOSITORY/"Library/Contributions"
 # Where downloaded files are cached.
 HOMEBREW_CACHE = Pathname.new(ENV['HOMEBREW_CACHE'] || HOMEBREW_LIBRARY/"Cache")
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula" # Where brews installed via URL are cached
-class << HOMEBREW_CACHE_FORMULA
-  alias mkpath_without_migrate mkpath
+
+require 'legacy_cache_migration'
+HOMEBREW_CACHE.extend(LegacyCacheMigration)
+HOMEBREW_CACHE_FORMULA.extend Module.new {
   def mkpath
-    HOMEBREW_CACHE.migrate! if not exist?   # make sure migration happens
-    mkpath_without_migrate
+    HOMEBREW_CACHE.migrate! unless exist?
+    super
   end
-end
-class << HOMEBREW_CACHE
-  alias mkpath_without_migrate mkpath
-  def mkpath
-    migrate! if not exist?   # make sure migration happens
-    mkpath_without_migrate
-  end
-
-  # Previous versions of Homebrew used a world-writable cache directory in
-  # /Library/Caches/Homebrew, or a user-owned cache directory in
-  # ~/Library/Caches/Homebrew.  There were security problems with that approach
-  # (see https://github.com/mxcl/homebrew/issues/23232) so now we just use a
-  # subdirectory of the repository.
-  #
-  # This migrates the old cache directory to the new location, where it's safe to do so.
-  def migrate!
-    # Nothing to migrate if the HOMEBREW_CACHE env var is set.
-    return if ENV['HOMEBREW_CACHE']
-
-    # Only migrate once, and make sure there's only one process doing the
-    # migration.
-    if HOMEBREW_CACHE.exist?
-      return
-    else
-      HOMEBREW_CACHE.dirname.mkpath
-      begin
-        HOMEBREW_CACHE.mkdir
-      rescue Errno::EEXIST
-        # Some other process created the directory.  Don't migrate.
-        return
-      end
-    end
-
-    # Previous versions of homebrew used ~/Library/Caches/Homebrew as a cache
-    # if it existed.  Attempt to migrate this to the new cache dir.
-    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
-    if home_cache.directory? and home_cache.writable_real?
-      Dir[home_cache/'*', home_cache/'.*'].each do |src|
-        src = Pathname.new(src)
-        next if ['.', '..'].include?(src.basename.to_s)
-        FileUtils.mv src, HOMEBREW_CACHE
-      end
-
-      # We don't remove the empty ~/Library/Caches/Homebrew.  It was created
-      # manually, and removing it could leave users insecure if they downgrade
-      # to an older version.
-      return
-    end
-
-    # Let's try the global cache instead.  This is tricky, because it might
-    # be/have been owned by another user, and getting this wrong could lead to
-    # privilege escalation.
-    1.times do
-      # Atomically get information about the path
-      begin
-        site_cache = Pathname.new("/Library/Caches/Homebrew")
-        st = site_cache.lstat
-      rescue Errno::ENOENT, Errno::EACCES
-        break
-      end
-
-      # We can't do anything if it's not a directory that we can write to.
-      break unless st.directory? and st.writable_real?
-
-      # Don't migrate if it would be unsafe.
-      # Note: This doesn't cover every possible unsafe situation that might
-      # have been created by the current user, but it should cover the case
-      # where a previous version of homebrew created a world-writable cache
-      # directory.
-      break if (st.mode & 2) != 0   # world-writable
-      break if !st.owned? and st.uid != 0   # owned by another user
-      break if st.symlink?  # is a symlink (potentially pointing somewhere dangerous)
-
-      # Migrate the files.
-      Dir[site_cache/'*', site_cache/'.*'].each do |src|
-        src = Pathname.new(src)
-        next if ['.', '..'].include?(src.basename.to_s)
-        FileUtils.mv src, HOMEBREW_CACHE
-      end
-
-      # We don't remove the empty /Library/Caches/Homebrew directory, because
-      # another process might be using it (hopefully not, but it's possible),
-      # and deleting it might allow an attacker to create a new directory in
-      # its place.
-      return
-    end
-  end
-end
+}
 
 # Where we store built products; /usr/local/Cellar if it exists,
 # otherwise a Cellar relative to the Repository.

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -16,37 +16,6 @@ ARGV.extend(HomebrewArgvExtension)
 HOMEBREW_VERSION = '0.9.5'
 HOMEBREW_WWW = 'http://brew.sh'
 
-def cache
-  if ENV['HOMEBREW_CACHE']
-    Pathname.new(ENV['HOMEBREW_CACHE'])
-  else
-    # we do this for historic reasons, however the cache *should* be the same
-    # directory whichever user is used and whatever instance of brew is executed
-    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
-    if home_cache.directory? and home_cache.writable_real?
-      home_cache
-    else
-      root_cache = Pathname.new("/Library/Caches/Homebrew")
-      class << root_cache
-        alias :oldmkpath :mkpath
-        def mkpath
-          unless exist?
-            oldmkpath
-            chmod 0777
-          end
-        end
-      end
-      root_cache
-    end
-  end
-end
-
-HOMEBREW_CACHE = cache
-undef cache # we use a function to prevent adding home_cache to the global scope
-
-# Where brews installed via URL are cached
-HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"
-
 if not defined? HOMEBREW_BREW_FILE
   HOMEBREW_BREW_FILE = ENV['HOMEBREW_BREW_FILE'] || which('brew').to_s
 end
@@ -55,6 +24,104 @@ HOMEBREW_PREFIX = Pathname.new(HOMEBREW_BREW_FILE).dirname.parent # Where we lin
 HOMEBREW_REPOSITORY = Pathname.new(HOMEBREW_BREW_FILE).realpath.dirname.parent # Where .git is found
 HOMEBREW_LIBRARY = HOMEBREW_REPOSITORY/"Library"
 HOMEBREW_CONTRIB = HOMEBREW_REPOSITORY/"Library/Contributions"
+
+# Where downloaded files are cached.
+HOMEBREW_CACHE = Pathname.new(ENV['HOMEBREW_CACHE'] || HOMEBREW_LIBRARY/"Cache")
+HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula" # Where brews installed via URL are cached
+class << HOMEBREW_CACHE_FORMULA
+  alias mkpath_without_migrate mkpath
+  def mkpath
+    HOMEBREW_CACHE.migrate! if not exist?   # make sure migration happens
+    mkpath_without_migrate
+  end
+end
+class << HOMEBREW_CACHE
+  alias mkpath_without_migrate mkpath
+  def mkpath
+    migrate! if not exist?   # make sure migration happens
+    mkpath_without_migrate
+  end
+
+  # Previous versions of Homebrew used a world-writable cache directory in
+  # /Library/Caches/Homebrew, or a user-owned cache directory in
+  # ~/Library/Caches/Homebrew.  There were security problems with that approach
+  # (see https://github.com/mxcl/homebrew/issues/23232) so now we just use a
+  # subdirectory of the repository.
+  #
+  # This migrates the old cache directory to the new location, where it's safe to do so.
+  def migrate!
+    # Nothing to migrate if the HOMEBREW_CACHE env var is set.
+    return if ENV['HOMEBREW_CACHE']
+
+    # Only migrate once, and make sure there's only one process doing the
+    # migration.
+    if HOMEBREW_CACHE.exist?
+      return
+    else
+      HOMEBREW_CACHE.dirname.mkpath
+      begin
+        HOMEBREW_CACHE.mkdir
+      rescue Errno::EEXIST
+        # Some other process created the directory.  Don't migrate.
+        return
+      end
+    end
+
+    # Previous versions of homebrew used ~/Library/Caches/Homebrew as a cache
+    # if it existed.  Attempt to migrate this to the new cache dir.
+    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
+    if home_cache.directory? and home_cache.writable_real?
+      Dir[home_cache/'*', home_cache/'.*'].each do |src|
+        src = Pathname.new(src)
+        next if ['.', '..'].include?(src.basename.to_s)
+        FileUtils.mv src, HOMEBREW_CACHE
+      end
+
+      # We don't remove the empty ~/Library/Caches/Homebrew.  It was created
+      # manually, and removing it could leave users insecure if they downgrade
+      # to an older version.
+      return
+    end
+
+    # Let's try the global cache instead.  This is tricky, because it might
+    # be/have been owned by another user, and getting this wrong could lead to
+    # privilege escalation.
+    1.times do
+      # Atomically get information about the path
+      begin
+        site_cache = Pathname.new("/Library/Caches/Homebrew")
+        st = site_cache.lstat
+      rescue Errno::ENOENT, Errno::EACCES
+        break
+      end
+
+      # We can't do anything if it's not a directory that we can write to.
+      break unless st.directory? and st.writable_real?
+
+      # Don't migrate if it would be unsafe.
+      # Note: This doesn't cover every possible unsafe situation that might
+      # have been created by the current user, but it should cover the case
+      # where a previous version of homebrew created a world-writable cache
+      # directory.
+      break if (st.mode & 2) != 0   # world-writable
+      break if !st.owned? and st.uid != 0   # owned by another user
+      break if st.symlink?  # is a symlink (potentially pointing somewhere dangerous)
+
+      # Migrate the files.
+      Dir[site_cache/'*', site_cache/'.*'].each do |src|
+        src = Pathname.new(src)
+        next if ['.', '..'].include?(src.basename.to_s)
+        FileUtils.mv src, HOMEBREW_CACHE
+      end
+
+      # We don't remove the empty /Library/Caches/Homebrew directory, because
+      # another process might be using it (hopefully not, but it's possible),
+      # and deleting it might allow an attacker to create a new directory in
+      # its place.
+      return
+    end
+  end
+end
 
 # Where we store built products; /usr/local/Cellar if it exists,
 # otherwise a Cellar relative to the Repository.

--- a/Library/Homebrew/legacy_cache_migration.rb
+++ b/Library/Homebrew/legacy_cache_migration.rb
@@ -1,0 +1,85 @@
+module LegacyCacheMigration
+  def mkpath
+    migrate! unless exist?
+    super
+  end
+
+  # Previous versions of Homebrew used a world-writable cache directory in
+  # /Library/Caches/Homebrew, or a user-owned cache directory in
+  # ~/Library/Caches/Homebrew.  There were security problems with that approach
+  # (see https://github.com/mxcl/homebrew/issues/23232) so now we just use a
+  # subdirectory of the repository.
+  #
+  # This migrates the old cache directory to the new location, where it's safe to do so.
+  def migrate!
+    # Nothing to migrate if the HOMEBREW_CACHE env var is set.
+    return if ENV['HOMEBREW_CACHE']
+
+    # Only migrate once, and make sure there's only one process doing the
+    # migration.
+    if HOMEBREW_CACHE.exist?
+      return
+    else
+      HOMEBREW_CACHE.dirname.mkpath
+      begin
+        HOMEBREW_CACHE.mkdir
+      rescue Errno::EEXIST
+        # Some other process created the directory.  Don't migrate.
+        return
+      end
+    end
+
+    # Previous versions of homebrew used ~/Library/Caches/Homebrew as a cache
+    # if it existed.  Attempt to migrate this to the new cache dir.
+    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
+    if home_cache.directory? and home_cache.writable_real?
+      Dir[home_cache/'*', home_cache/'.*'].each do |src|
+        src = Pathname.new(src)
+        next if ['.', '..'].include?(src.basename.to_s)
+        FileUtils.mv src, HOMEBREW_CACHE
+      end
+
+      # We don't remove the empty ~/Library/Caches/Homebrew.  It was created
+      # manually, and removing it could leave users insecure if they downgrade
+      # to an older version.
+      return
+    end
+
+    # Let's try the global cache instead.  This is tricky, because it might
+    # be/have been owned by another user, and getting this wrong could lead to
+    # privilege escalation.
+
+    # Atomically get information about the path
+    begin
+      site_cache = Pathname.new("/Library/Caches/Homebrew")
+      st = site_cache.lstat
+    rescue Errno::ENOENT, Errno::EACCES
+      return
+    end
+
+    # We can't do anything if it's not a directory that we can write to.
+    return unless st.directory? and st.writable_real?
+
+    # Don't migrate if it would be unsafe.
+    # Note: This doesn't cover every possible unsafe situation that might
+    # have been created by the current user, but it should cover the case
+    # where a previous version of homebrew created a world-writable cache
+    # directory.
+    return if (st.mode & 2) != 0   # world-writable
+    return if !st.owned? and st.uid != 0   # owned by another user
+    return if st.symlink?  # is a symlink (potentially pointing somewhere dangerous)
+
+    # Migrate the files.
+    Dir[site_cache/'*', site_cache/'.*'].each do |src|
+      src = Pathname.new(src)
+      next if ['.', '..'].include?(src.basename.to_s)
+      FileUtils.mv src, HOMEBREW_CACHE
+    end
+
+    # We don't remove the empty /Library/Caches/Homebrew directory, because
+    # another process might be using it (hopefully not, but it's possible),
+    # and deleting it might allow an attacker to create a new directory in
+    # its place.
+    return
+  end
+end

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -511,7 +511,7 @@ HOMEBREW_CACHE
 If set, instructs Homebrew to use the given directory as the download cache\.
 .
 .IP
-\fIDefault:\fR \fB~/Library/Caches/Homebrew\fR if it exists; otherwise, \fB/Library/Caches/Homebrew\fR\.
+\fIDefault:\fR \fB$(brew \-\-repository)/Library/Cache\fR
 .
 .TP
 HOMEBREW_CURL_VERBOSE


### PR DESCRIPTION
This pull request is to remove the world-writable cache in /Library/Caches/Homebrew.  The world-writable cache allows a process running under any uid to hijack another user's `brew install` session.

It's still possible to use a world-writable cache by creating it yourself and setting HOMEBREW_CACHE in the environment, but it would no longer be the default behavior.

Closes #23232