### PR TITLE
Don't `write_exec_script`s for non-executables.

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -360,10 +360,12 @@ class Pathname
     mkpath
     targets.each do |target|
       target = Pathname.new(target) # allow pathnames or strings
-      (self+target.basename()).write <<-EOS.undent
-        #!/bin/bash
-        exec "#{target}" "$@"
-      EOS
+      if target.file? && target.executable?
+        (self+target.basename()).write <<-EOS.undent
+          #!/bin/bash
+          exec "#{target}" "$@"
+        EOS
+      end
     end
   end
 


### PR DESCRIPTION
Take a look at what gets linked into `bin` after `brew install hbase` — you've now got a `test` taking precedence over `/bin/test`, trying to exec a directory. This totally fries shells where `test` isn't a builtin. :scream:

I think this should do it?