### PR TITLE
tokyo-tyrant: added patch to fix unix socket issue

### DIFF
--- a/Library/Formula/tokyo-tyrant.rb
+++ b/Library/Formula/tokyo-tyrant.rb
@@ -4,7 +4,7 @@ class TokyoTyrant < Formula
   homepage 'http://fallabs.com/tokyotyrant/'
   url 'http://fallabs.com/tokyotyrant/tokyotyrant-1.1.41.tar.gz'
   sha1 '060ac946a9ac902c1d244ffafd444f0e5840c0ce'
-  revision 1
+  revision 2
 
   option "no-lua", "Disable Lua support"
 

--- a/Library/Formula/tokyo-tyrant.rb
+++ b/Library/Formula/tokyo-tyrant.rb
@@ -4,7 +4,7 @@ class TokyoTyrant < Formula
   homepage 'http://fallabs.com/tokyotyrant/'
   url 'http://fallabs.com/tokyotyrant/tokyotyrant-1.1.41.tar.gz'
   sha1 '060ac946a9ac902c1d244ffafd444f0e5840c0ce'
-  revision 1
+  revision 2
 
   option "no-lua", "Disable Lua support"
 
@@ -13,6 +13,11 @@ class TokyoTyrant < Formula
 
   unless build.include? "no-lua"
     patch :DATA
+  end
+
+  patch :p0 do
+    url 'https://gist.githubusercontent.com/actsasflinn/348633/raw/32561ebf6487650ce86d0184f0ca35bb8110d04c/macosx_snow_leopard_socket_fix.patch'
+    sha1 '2b73fe52c37cd41b8e13112c0bc083bce8ae3c9e'
   end
 
   def install

--- a/Library/Formula/tokyo-tyrant.rb
+++ b/Library/Formula/tokyo-tyrant.rb
@@ -4,7 +4,7 @@ class TokyoTyrant < Formula
   homepage 'http://fallabs.com/tokyotyrant/'
   url 'http://fallabs.com/tokyotyrant/tokyotyrant-1.1.41.tar.gz'
   sha1 '060ac946a9ac902c1d244ffafd444f0e5840c0ce'
-  revision 2
+  revision 1
 
   option "no-lua", "Disable Lua support"
 
@@ -15,9 +15,11 @@ class TokyoTyrant < Formula
     patch :DATA
   end
 
-  patch :p0 do
-    url 'https://gist.githubusercontent.com/actsasflinn/348633/raw/32561ebf6487650ce86d0184f0ca35bb8110d04c/macosx_snow_leopard_socket_fix.patch'
-    sha1 '2b73fe52c37cd41b8e13112c0bc083bce8ae3c9e'
+  patch do
+    # Patch to fix UNIX socket issue
+    # https://gist.github.com/bow-fujita/a338e35b95605ad63147
+    url 'https://gist.githubusercontent.com/bow-fujita/a338e35b95605ad63147/raw/3bd1bb84ea58f7a71a485fe032299def3a288576/tokyotyrant-fix-unix-socket.patch'
+    sha1 'dd76282b0ea99104372c8da09e564f308d83ffdf'
   end
 
   def install


### PR DESCRIPTION
ttserver doesn't open unix socket even with command options `-host /path/to/socket -p 0`.
I added the patch introduced in [Tokyo Tyrant patch fix unix sockets on Mac OSX Snow Leopard](http://actsasflinn.com/post/482955247/tokyo-tyrant-patch-unix-socket-snow-leopard).
I confirmed it worked with tokyotyrant-1.1.41 on Yosemite, although this article was posted 6 years ago and the patch was applied to tokyotyrant-1.1.40.