### PR TITLE
pathname: Ensure symlink paths are based on real paths

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -70,10 +70,10 @@ class Pathname
   end
 
   def install_symlink_p(src, new_basename)
-    src = Pathname(src).expand_path(self)
+    src = Pathname(src).realpath
     dst = join(new_basename)
     mkpath
-    FileUtils.ln_sf(src.relative_path_from(dst.parent), dst)
+    FileUtils.ln_sf(src.relative_path_from(dst.parent.realpath), dst)
   end
   private :install_symlink_p
 


### PR DESCRIPTION
Previously, if a symlink was to be installed into a folder that was
itself under a symlink, the calculated relative path would result in an
invalid link. This is prevented by converting the paths used to the
actual on-disk paths first.