### PR TITLE
riak: add advice about ulimit settings when too low

### DIFF
--- a/Library/Formula/riak.rb
+++ b/Library/Formula/riak.rb
@@ -1,8 +1,6 @@
-require "formula"
-
 class Riak < Formula
-  desc "Distributed database"
   homepage "http://basho.com/riak/"
+  desc "Riak is a distributed NoSQL key-value data store."
   url "https://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.1/osx/10.8/riak-2.1.1-OSX-x86_64.tar.gz"
   version "2.1.1"
   sha256 "ee06193b5fc4bb56746f8f648794b732b96879369835a94f22235e0561d652d7"
@@ -29,5 +27,41 @@ class Riak < Formula
     bin.write_exec_script libexec/"bin/riak-admin"
     bin.write_exec_script libexec/"bin/riak-debug"
     bin.write_exec_script libexec/"bin/search-cmd"
+  end
+
+  def recommended_maxfiles
+    65536
+  end
+
+  def recommended_maxproc
+    2048
+  end
+
+  def caveats
+    msg = nil
+    if maxfiles_too_low? || maxprocs_too_low?
+      msg = "Your maxfiles limit or maxprocs limit is too low.  See the riak docs:\n"
+      msg << "http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/"
+    end
+
+    msg
+  end
+
+  def maxfiles_too_low?
+    maxfiles = `launchctl limit maxfiles`
+    _, maxfiles_soft, maxfiles_hard = maxfiles.split
+
+    maxfiles_soft.to_i < recommended_maxfiles || maxfiles_hard.to_i < recommended_maxfiles
+  end
+
+  def maxprocs_too_low?
+    maxproc= `launchctl limit maxproc`
+    _, maxproc_soft, maxproc_hard = maxproc.split
+
+    maxproc_soft.to_i < recommended_maxproc || maxproc_hard.to_i < recommended_maxproc
+  end
+
+  test do
+    system "#{bin}/riak", "help", "0"
   end
 end


### PR DESCRIPTION
`brew audit --strict riak` complains about openssl being linked but it was doing that before my change:

    ==> audit problems
    riak:
     * object files were linked against system openssl
     These object files were linked against the deprecated system OpenSSL.
    Adding `depends_on "openssl"` to the formula may help.
      /usr/local/Cellar/riak/2.0.4/libexec/lib/crypto-3.1/priv/lib/crypto.so

Also, a file from the basho tarball is already linked:

    otool -L /usr/local/Cellar/riak/2.0.4/libexec/lib/crypto-3.1/priv/lib/crypto.so
      /usr/local/Cellar/riak/2.0.4/libexec/lib/crypto-3.1/priv/lib/crypto.so:
      /usr/lib/libcrypto.0.9.8.dylib (compatibility version 0.9.8, current version 47.1.0)
      /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 169.3.0)

Outside that, I tested the new formula and it works.  There's some complexity around suggesting what to do about maxfiles and other limits on Yosemite (the process has changed), so I left post_install.  Hopefully that doesn't bit rot as fast as make a suggestion of what to do from the formula.

I tried to get a plist to work but launchctl is not happy with a forking Erlang process.  I can get it to boot with homebrew but not stop.  So, that's not in here.  :(  If anyone has advice to get this to autoboot (with `launchctl`), please reach out to me, I'm curious about this.
