### PR TITLE
percona-toolkit does not depend on MySQL

### DIFF
--- a/Library/Formula/percona-toolkit.rb
+++ b/Library/Formula/percona-toolkit.rb
@@ -13,7 +13,6 @@ class PerconaToolkit < Formula
     sha256 "95fec4e6b45806a11c940c48f6e811101e7bf711aba758783762b2133229b08f" => :mountain_lion
   end
 
-  depends_on :mysql
   depends_on "openssl"
 
   resource "DBD::mysql" do


### PR DESCRIPTION
There are three MySQL forks on homebrew now: `mysql`, `mariadb`, and `percona-server`. One could want to use `percona-toolkit` with any of them, or even a remote database server, so you shouldn't need to install `mysql` (which conflicts with `mariadb` and `percona-server`) for it to work.

It turns out that installing the `DBD::mysql` dependency does not require `libmysql` to be installed, so it seems fine to just remove it as a dependency. To test this I removed this line locally with `brew edit percona-toolkit`, uninstalled `mariadb`, and did `brew install --fresh percona-toolkit`. It worked, and the `pt-summary` command (which doesn't connect to MySQL at all) worked fine. Then I installed `mariadb` again, and ran `pt-mysql-summary` which also worked fine.