### PR TITLE
libmemcached: enhanced coverage options

### DIFF
--- a/Library/Formula/libmemcached.rb
+++ b/Library/Formula/libmemcached.rb
@@ -1,10 +1,8 @@
-require "formula"
-
 class Libmemcached < Formula
   desc "C and C++ client library to the memcached server"
   homepage "http://libmemcached.org"
   url "https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz"
-  sha1 "8be06b5b95adbc0a7cb0f232e237b648caf783e1"
+  sha256 "e22c0bb032fde08f53de9ffbc5a128233041d9f33b5de022c0978a2149885f82"
   revision 1
 
   bottle do
@@ -15,7 +13,11 @@ class Libmemcached < Formula
   end
 
   option "with-sasl", "Build with sasl support"
+  option "with-static", "Build static library"
+  option "with-memaslap", "Build with load generation and benchmark tool support"
+  option "with-hsieh-hash", "Build with hsieh hashing support"
 
+  depends_on "libevent" # requires --enable-libmemcachedprotocol
   if build.with? "sasl"
     depends_on "memcached" => "enable-sasl"
   else
@@ -28,14 +30,20 @@ class Libmemcached < Formula
   def install
     ENV.append_to_cflags "-undefined dynamic_lookup" if MacOS.version <= :leopard
 
-    args = ["--prefix=#{prefix}"]
-
-    if build.with? "sasl"
-      args << "--with-memcached-sasl=#{Formula["memcached"].bin}/memcached"
-    end
+    args = [
+      "--prefix=#{prefix}",
+      "--disable-dependency-tracking",
+      "--enable-libmemcachedprotocol",
+      "--with-memcached=#{Formula["memcached"].opt_bin}/memcached",
+      "--enable-shared"
+    ]
+    args << "--enable-static=no" if build.without? "static"
+    args << "--disable-sasl" if build.without? "sasl"
+    args << "--enable-memaslap" if build.with? "memaslap"
+    args << "--enable-hsieh_hash" if build.with? "hsieh-hash"
 
     system "./configure", *args
-    system "make install"
+    system "make", "install"
   end
 end
 


### PR DESCRIPTION
###### Enhanced coverage options, fixed value `--with-memcached-sasl`:
- Support memcached protocol (requires libevent2)
- Support load generation and benchmark tool
- Support hsieh hashing
- Static library optional, `depends_on "libmemcached" => "with-static"`