### PR TITLE
cowpatty: some small patches which makes correct use of stdin

### DIFF
--- a/Library/Formula/cowpatty.rb
+++ b/Library/Formula/cowpatty.rb
@@ -11,7 +11,12 @@ class Cowpatty < Formula
     sha256 "35fba0f92c5e8fb0710453d0c2c5fe5e9c64857dd53b219977871340b22c4942"
   end
 
+  def patches
+    [ "http://proton.cygnusx-1.org/~edgan/cowpatty/cowpatty-4.6-fixup16.patch" ]
+  end
+
   def install
+    system "make"
     system "make", "BINDIR=#{bin}", "install"
   end
 

--- a/Library/Formula/cowpatty.rb
+++ b/Library/Formula/cowpatty.rb
@@ -11,8 +11,9 @@ class Cowpatty < Formula
     sha256 "35fba0f92c5e8fb0710453d0c2c5fe5e9c64857dd53b219977871340b22c4942"
   end
 
-  def patches
-    [ "http://proton.cygnusx-1.org/~edgan/cowpatty/cowpatty-4.6-fixup16.patch" ]
+  patch do
+    url "http://proton.cygnusx-1.org/~edgan/cowpatty/cowpatty-4.6-fixup16.patch"
+    sha256 "2cf392c4dec543a6d77d7d420dae231938df3ba427e30f05256f6ab5baa47e5d"
   end
 
   def install


### PR DESCRIPTION
Now you can be able to pass output from pyrit over stdout/stdin directly to cowpatty.