### PR TITLE
languages: flag missing dependency requirement

### DIFF
--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -19,7 +19,8 @@ class LanguageModuleRequirement < Requirement
         `#{command_line} #{@module_name}`
     EOS
 
-    if $?.exitstatus == 127
+    sys_prov = :python || :perl || :ruby
+    unless @language == sys_prov
       s << <<-EOS.undent
 
       You may need to: `brew install #{@language}`

--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -12,11 +12,22 @@ class LanguageModuleRequirement < Requirement
 
   satisfy(:build_env => false) { quiet_system(*the_test) }
 
-  def message; <<-EOS.undent
-    Unsatisfied dependency: #{@module_name}
-    Homebrew does not provide #{@language.to_s.capitalize} dependencies; install with:
-      #{command_line} #{@module_name}
+  def message
+    s = <<-EOS.undent
+      Unsatisfied dependency: #{@module_name}
+      Homebrew does not provide special #{@language.to_s.capitalize} dependencies; install with:
+        `#{command_line} #{@module_name}`
     EOS
+
+    if $?.exitstatus == 127
+      s << <<-EOS.undent
+
+      You may need to: `brew install #{@language}`
+
+      EOS
+    end
+
+    s
   end
 
   def the_test


### PR DESCRIPTION
I'm aware this is probably more complicated than it needs to be and Xu is likely to see this, drive by and go *"Or you can compress all of this down to these two easy lines"* :stuck_out_tongue_winking_eye:.

This is in part designed to handle situations described in #42273 where we tell someone to install a special dependency, but because we (rightly, IMO) resolve special dependencies first users can end up being told to execute a command on a tool that isn't yet installed and isn't immediately obvious how to install it.

In the situation raised there, with the `sile` formula people are being told to `luarocks install xyz` but we hadn't installed Lua for them first, so they just get a `command not found: luarocks` message. Perhaps it should be obvious enough how to install said tools by looking at the formula's dependencies, but it's not a huge burden on us to make life easier than that.

Essentially, when `lua` isn't already installed this changes the current message to:

```
sile: Unsatisfied dependency: lpeg
Homebrew does not provide special Lua dependencies; install with:
  luarocks-5.2 install lpeg
You may need to:
  brew install lua
Error: Unsatisfied requirements failed this build.
```

If Lua is installed but the special dependency isn't the message stays at:

```
sile: Unsatisfied dependency: lpeg
Homebrew does not provide special Lua dependencies; install with:
  luarocks-5.2 install lpeg
Error: Unsatisfied requirements failed this build.
```

The only thing it won't flag that doesn't already come shipped with OS X is the `rbx` dependency as there's no way to install that via `brew`. It won't flag Perl/Python/Ruby stuff because `/usr/bin/env` returns the exit code `127` if a tool doesn't exist, but the tools themselves return an exit code of `1` or `2` if the tool exists but the special dependency isn't installed.

I need to check a few of the remaining ones, but `127` should be a safe check as it's *supposed* to be reserved for "command not found".