### PR TITLE
boot-clj: in `post_install`, update Boot lib too.

### DIFF
--- a/Library/Formula/boot-clj.rb
+++ b/Library/Formula/boot-clj.rb
@@ -10,7 +10,6 @@ class BootClj < Formula
   end
 
   def post_install
-
     # Work correctly in sandboxes.
     # (Q.v. <https://github.com/Homebrew/homebrew/pull/44254>)
     ENV["_JAVA_OPTIONS"] = "-Duser.home=#{ENV["HOME"]}"

--- a/Library/Formula/boot-clj.rb
+++ b/Library/Formula/boot-clj.rb
@@ -9,6 +9,12 @@ class BootClj < Formula
     bin.install "boot.sh" => "boot"
   end
 
+  def post_install
+    # Use the wrapper to update Boot's JAR files too.
+    # (Q.v. <https://github.com/boot-clj/boot/tree/2.2.0#install>)
+    system bin/"boot", "--update"
+  end
+
   test do
     system "#{bin}/boot", "repl", "-e", "(System/exit 0)"
   end

--- a/Library/Formula/boot-clj.rb
+++ b/Library/Formula/boot-clj.rb
@@ -10,6 +10,11 @@ class BootClj < Formula
   end
 
   def post_install
+
+    # Work correctly in sandboxes.
+    # (Q.v. <https://github.com/Homebrew/homebrew/pull/44254>)
+    ENV["_JAVA_OPTIONS"] = "-Duser.home=#{ENV["HOME"]}"
+
     # Use the wrapper to update Boot's JAR files too.
     # (Q.v. <https://github.com/boot-clj/boot/tree/2.2.0#install>)
     system bin/"boot", "--update"


### PR DESCRIPTION
Without this change, the “Boot App Version” could get ahead of the “Boot
Lib Version”. (Which isn’t *problem* per se but it’s potentially
surprising.) The following shell interaction demonstrates the multiple
versions at play:

```
$ boot -h
Boot App Version: 2.0.0
Boot Lib Version: 2.1.2
Clojure Version:  1.6.0
…
$ brew upgrade boot-clj
…
$ boot -h
Boot App Version: 2.2.0
Boot Lib Version: 2.1.2
Clojure Version:  1.6.0
…
$ boot -u
…
$ boot -h
Boot App Version: 2.2.0
Boot Lib Version: 2.2.0
Clojure Version:  1.7.0
…
```