### PR TITLE
ossp-uuid patch pkg-config to use configured dirs

### DIFF
--- a/Library/Formula/ossp-uuid.rb
+++ b/Library/Formula/ossp-uuid.rb
@@ -5,7 +5,7 @@ class OsspUuid < Formula
   mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
   mirror "ftp://ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz"
   sha256 "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -25,6 +25,13 @@ class OsspUuid < Formula
     elsif build.build_32_bit?
       ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
     end
+
+# upstream ticket: http://cvs.ossp.org/tktview?tn=200
+# pkg-config --cflags uuid returns the wrong directory since we override the
+# default, but uuid.pc.in does not use it
+    inreplace "uuid.pc.in", /^(exec_prefix)=\$\{prefix\}$/, '\1=@\1@'
+    inreplace "uuid.pc.in", /^(includedir)=\$\{prefix\}\/include$/, '\1=@\1@'
+    inreplace "uuid.pc.in", /^(libdir)=\$\{exec_prefix\}\/lib$/, '\1=@\1@'
 
     system "./configure", "--prefix=#{prefix}",
                           "--includedir=#{include}/ossp",


### PR DESCRIPTION
Patch ossp-uuid/uuid.pc.in to use the configure directories for includes. Also bump revision from 1 to 2.
Unfortunately from the look of upstream's CVS repository it seems it has been inactive for years, so I'm afraid the chances of a new release are quite low.

Tested on Debian via LinuxBrew:

```
$ bin/brew install ossp-uuid
Warning: Formula file is modified!
Building from source because Library/Formula/ossp-uuid.rb has local changes
To install from a bottle instead, run with --force-bottle
/usr/bin/gcc-4.2: not found (maybe gcc-4.2 is not installed?)
==> Downloading http://ftp.de.debian.org/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz
Already downloaded: /home/luca/.cache/Homebrew/ossp-uuid-1.6.2.tar.gz
==> Patching
patching file uuid.pc.in
==> ./configure --prefix=/home/luca/git/linuxbrew/Cellar/ossp-uuid/1.6.2_2 --includedir=/home/luca/git/linuxbrew/Cella
==> make
==> make install
/home/luca/git/linuxbrew/Cellar/ossp-uuid/1.6.2_2: 16 files, 292K, built in 4 seconds
$ PKG_CONFIG_PATH=/home/luca/git/linuxbrew/Cellar/ossp-uuid/1.6.2_2/lib/pkgconfig pkg-config --libs --cflags uuid
-I/home/luca/git/linuxbrew/Cellar/ossp-uuid/1.6.2_2/include/ossp -L/home/luca/git/linuxbrew/Cellar/ossp-uuid/1.6.2_2/lib -luuid
```

pkg-config now returns correctly <...>include/ossp instead of <...>/include.

Fixes issue #43843, upstream ticket: http://cvs.ossp.org/tktview?tn=200