### PR TITLE
gpac: explicitly disable pulseaudio dep to avoid linkage error.

### DIFF
--- a/Library/Formula/gpac.rb
+++ b/Library/Formula/gpac.rb
@@ -36,9 +36,11 @@ class Gpac < Formula
   depends_on "openjpeg" => :optional
 
   def install
-    args = ["--disable-wx",
+    # If pulseaudio is linked, the script detects it, but fails to link -lpulse.
+    args = ["--disable-pulseaudio",
+            "--disable-wx",
             "--prefix=#{prefix}",
-            "--mandir=#{man}"]
+            "--mandir=#{man}",]
 
     if build.with? "x11"
       # gpac build system is barely functional


### PR DESCRIPTION
`brew install pulseaudio mp4box` should be sufficient to reproduce.
In keeping with the "minimal" approach of the formula, I thought this was the simplest way to take care of it.

On a side note, this formula clearly installs as 'gpac.0.5.1-DEV', not v5.2; that single, solitary "release" is most certainly an anomaly, and the homepage basically that they do not *do* stable releases; using the nightlies is explicitly encouraged. So maybe a candidate for head-only...