### PR TITLE
Replace GNU patch with git apply for applying patches

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -64,9 +64,12 @@ class EmbeddedPatch
   end
 
   def apply
+    Utils.ensure_git_installed!
+
     data = contents.gsub("HOMEBREW_PREFIX", HOMEBREW_PREFIX)
-    cmd = "/usr/bin/patch"
-    args = %W[-g 0 -f -#{strip}]
+    cmd = "git"
+    args = %W[apply -p #{strip[1..-1]}]
+
     IO.popen("#{cmd} #{args.join(" ")}", "w") { |p| p.write(data) }
     raise ErrorDuringExecution.new(cmd, args) unless $?.success?
   end


### PR DESCRIPTION
This PR replaces the default patching tool used by Homebrew from GNU patch to Git.

Since Git is the [preferred tool](https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/build.rb#L121) for getting diffs when editing, it would make sense to apply these diffs using Git as well. Additionally, as I read it, the version of GNU patch that comes with OS X (version 2.5.8 as of OS X 10.11) does not fully support the the Git diff format, only supporting "[most features](http://savannah.gnu.org/forum/forum.php?forum_id=7361)" of it in version 2.7.

As a personal thing, this fixes #44436 by letting me define a symlink as a patch, before the `--interactive phase` of `brew install` kicks in.

I ran this PR through `brew tests` and it passed, don't know how else to test it apart from real-world usage, where I haven't had any problems. Also I'm not sure whether `ensure_git_installed!` is really necessary.