### PR TITLE
zabbix: add foreground mode using patch

### DIFF
--- a/Library/Formula/zabbix.rb
+++ b/Library/Formula/zabbix.rb
@@ -12,6 +12,7 @@ class Zabbix < Formula
 
   option "with-mysql", "Use Zabbix Server with MySQL library instead PostgreSQL."
   option "without-server-proxy", "Install only the Zabbix Agent without Server and Proxy."
+  option "with-foreground-mode-patch", "Install Zabbix with foreground patch https://support.zabbix.com/browse/ZBXNEXT-611"
 
   deprecated_option "agent-only" => "without-server-proxy"
 
@@ -20,6 +21,17 @@ class Zabbix < Formula
     depends_on :postgresql if build.without? "mysql"
     depends_on "fping"
     depends_on "libssh2"
+  end
+
+  # To resolve problem with foreground mode with zabbix https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html#//apple_ref/doc/uid/10000172i-SW7-104302
+  # https://support.zabbix.com/browse/ZBXNEXT-611
+  # Using patch from openSUSE Build Service
+  # https://build.opensuse.org/package/show/server:monitoring:zabbix/zabbix24
+  if build.with? "foreground-mode-patch"
+    patch :p0 do
+      url "https://build.opensuse.org/source/server:monitoring:zabbix/zabbix24/zabbix-2.4.6-run_foreground.patch?rev=dcd5879d64aadd123cb868914d56d6e1"
+      sha256 "063b0c6a766ff64006b45a8a683e948b26c7c314efbab2ba50875f02522076a7"
+    end
   end
 
   def brewed_or_shipped(db_config)


### PR DESCRIPTION
[launchd requires daemons to run in foreground mode](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html#//apple_ref/doc/uid/10000172i-SW7-104302), but zabbix still [didn't support it](https://support.zabbix.com/browse/ZBXNEXT-611), so we can add it using patch from Boris Manojlovic, which is already used it in [opensuse](https://build.opensuse.org/package/show/server:monitoring:zabbix/zabbix24)