### PR TITLE
set Java user.home for builds

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1381,12 +1381,15 @@ class Formula
       mkdir_p env_home
 
       old_home, ENV["HOME"] = ENV["HOME"], env_home
+      old_java_options = ENV["_JAVA_OPTIONS"]
+      ENV.append "_JAVA_OPTIONS", "-Duser.home=#{env_home}"
 
       begin
         yield
       ensure
         @buildpath = nil
         ENV["HOME"] = old_home
+        ENV["_JAVA_OPTIONS"] = old_java_options
       end
     end
   end


### PR DESCRIPTION
Java doesn't respect $HOME. Maven attempts to write to the home
directory during builds, so Maven builds will fail unless we set the
user.home property or configure it not to use a local package cache.

This feels kinda gross to me but I think this is the only place to do this because this is the soonest we learn what HOME will be.

I'd also like to do this for the test environment; there's a setup_test_home that I'd like to repurpose for `install` as well and maybe this can be combined with that.