### PR TITLE
recommend python -m pip

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -315,10 +315,10 @@ class Python < Formula
 
   def caveats; <<-EOS.undent
     Pip and setuptools have been installed. To update them
-      pip install --upgrade pip setuptools
+      python -m pip install --upgrade pip setuptools
 
     You can install Python packages with
-      pip install <package>
+      python -m pip install <package>
 
     They will install into the site-package directory
       #{site_packages}

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -306,10 +306,10 @@ class Python3 < Formula
   def caveats
     text = <<-EOS.undent
       Pip and setuptools have been installed. To update them
-        pip3 install --upgrade pip setuptools
+        python3 -m pip install --upgrade pip setuptools
 
       You can install Python packages with
-        pip3 install <package>
+        python3 -m pip install <package>
 
       They will install into the site-package directory
         #{site_packages}


### PR DESCRIPTION
This invocation is more verbose but more deterministic; the `pip` script
can be overwritten when pip is upgraded under python3, which creates
confusion.

This aligns with the intent-to-deprecate discussion for the pip scripts
in e.g. pypa/pip issue 3164.