### PR TITLE
memcached: Add user flag to plist template

### DIFF
--- a/Library/Formula/memcached.rb
+++ b/Library/Formula/memcached.rb
@@ -47,6 +47,8 @@ class Memcached < Formula
         <string>#{opt_bin}/memcached</string>
         <string>-l</string>
         <string>localhost</string>
+        <string>-u</string>
+        <string>nobody</string>
       </array>
       <key>RunAtLoad</key>
       <true/>


### PR DESCRIPTION
This allows `brew services` to launch memcached from the root user. It is safely ignored if run as a non-privileged user.