### PR TITLE
freeswitch: add additional modules as options

### DIFF
--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -140,7 +140,7 @@ class Freeswitch < Formula
   #------------------------ End sound file resources --------------------------
 
   def install
-    ENV.deparallelize
+    ENV.deparallelize # makefile probably has a race condition, reported at: https://freeswitch.org/jira/browse/FS-8367
     system "./bootstrap.sh", "-j"
 
     # tiff will fail to find OpenGL unless told not to use X

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -17,8 +17,8 @@ class Freeswitch < Formula
   option "without-sounds-en", "Do not install English (Callie) sounds"
   option "with-sounds-fr", "Install French (June) sounds"
   option "with-sounds-ru", "Install Russian (Elena) sounds"
-  option "without-directory", "Install directory module"
-  option "without-flite", "Install text-to-speech module"
+  option "with-directory", "Install directory module"
+  option "with-flite", "Install text-to-speech module"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -17,6 +17,8 @@ class Freeswitch < Formula
   option "without-sounds-en", "Do not install English (Callie) sounds"
   option "with-sounds-fr", "Install French (June) sounds"
   option "with-sounds-ru", "Install Russian (Elena) sounds"
+  option "with-directory", "Install directory module"
+  option "with-flite", "Install text-to-speech module"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -148,6 +150,14 @@ class Freeswitch < Formula
                           "--enable-static",
                           "--prefix=#{prefix}",
                           "--exec_prefix=#{prefix}"
+
+    if build.with?("flite")
+      inreplace "modules.conf", "#asr_tts/mod_flite", "asr_tts/mod_flite"
+    end
+
+    if build.with?("directory")
+      inreplace "modules.conf", "#applications/mod_directory", "applications/mod_directory"
+    end
 
     system "make"
     system "make", "install", "all"

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -17,8 +17,8 @@ class Freeswitch < Formula
   option "without-sounds-en", "Do not install English (Callie) sounds"
   option "with-sounds-fr", "Install French (June) sounds"
   option "with-sounds-ru", "Install Russian (Elena) sounds"
-  option "with-directory", "Install directory module"
-  option "with-flite", "Install text-to-speech module"
+  option "without-directory", "Install directory module"
+  option "without-flite", "Install text-to-speech module"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -140,6 +140,7 @@ class Freeswitch < Formula
   #------------------------ End sound file resources --------------------------
 
   def install
+    ENV.deparallelize
     system "./bootstrap.sh", "-j"
 
     # tiff will fail to find OpenGL unless told not to use X

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -149,8 +149,19 @@ class Freeswitch < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--enable-shared",
                           "--enable-static",
-                          "--prefix=#{prefix}",
-                          "--exec_prefix=#{prefix}"
+                          "--prefix=#{etc}/freeswitch",
+                          "--exec_prefix=#{prefix}",
+                          "--with-htdocsdir=#{doc}/htdocs",
+                          "--includedir=#{include}",
+                          "--with-modinstdir=#{prefix}/mod",
+                          "--with-logfiledir=#{var}/log/#{name}",
+                          "--localstatedir=#{var}/#{name}",
+                          "--with-rundir=#{var}/run/#{name}",
+                          "--with-dbdir=#{var}/#{name}/db",
+                          "--with-soundsdir=#{var}/#{name}/sounds",
+                          "--with-recordingsdir=#{var}/#{name}/recordings",
+                          "--with-storagedir=#{var}/#{name}/storage",
+                          "--with-cachedir=#{var}/#{name}/cache"
 
     if build.with?("flite")
       inreplace "modules.conf", "#asr_tts/mod_flite", "asr_tts/mod_flite"
@@ -168,7 +179,7 @@ class Freeswitch < Formula
       mkdir_p prefix/"sounds/music"
       [8, 16, 32, 48].each do |n|
         resource("sounds-music-#{n}000").stage do
-          cp_r ".", prefix/"sounds/music"
+          cp_r ".", var/"#{name}/sounds/music"
         end
       end
     end
@@ -178,7 +189,7 @@ class Freeswitch < Formula
       mkdir_p prefix/"sounds/en"
       [8, 16, 32, 48].each do |n|
         resource("sounds-en-us-callie-#{n}000").stage do
-          cp_r ".", prefix/"sounds/en"
+          cp_r ".", var/"#{name}/sounds/en"
         end
       end
     end
@@ -188,7 +199,7 @@ class Freeswitch < Formula
       mkdir_p prefix/"sounds/fr"
       [8, 16, 32, 48].each do |n|
         resource("sounds-fr-ca-june-#{n}000").stage do
-          cp_r ".", prefix/"sounds/fr"
+          cp_r ".", var/"#{name}/sounds/fr"
         end
       end
     end
@@ -198,7 +209,7 @@ class Freeswitch < Formula
       mkdir_p prefix/"sounds/ru"
       [8, 16, 32, 48].each do |n|
         resource("sounds-ru-RU-elena-#{n}000").stage do
-          cp_r ".", prefix/"sounds/ru"
+          cp_r ".", var/"#{name}/sounds/ru"
         end
       end
     end


### PR DESCRIPTION
Minimum changes to add building some more modules (flite and directory) as options. These are extremely useful and including Flite is even recommended by upstream.

Hopefully it builds.