### PR TITLE
openssl: add 'enable-ssl-trace' option

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -16,6 +16,7 @@ class Openssl < Formula
 
   option :universal
   option "without-check", "Skip build-time tests (not recommended)"
+  option "with-trace", "Enable s_client support for the -trace option"
 
   depends_on "makedepend" => :build
 
@@ -61,7 +62,9 @@ class Openssl < Formula
       end
 
       ENV.deparallelize
-      system "perl", "./Configure", *(configure_args + arch_args[arch])
+      args = configure_args
+      args << "enable-ssl-trace" if build.with? "trace"
+      system "perl", "./Configure", *(args + arch_args[arch])
       system "make", "depend"
       system "make"
 


### PR DESCRIPTION
The enable-ssl-trace build flag allows the -trace option to be passed to
openssl s_client, which shows verbose, human-readable trace output of
protocol messages. https://www.openssl.org/docs/manmaster/apps/s_client.html