### PR TITLE
add a test to cvc4 to expose current bug

### DIFF
--- a/Library/Formula/cvc4.rb
+++ b/Library/Formula/cvc4.rb
@@ -45,5 +45,15 @@ class Cvc4 < Formula
     EOS
     result = shell_output "#{bin}/cvc4 #{(testpath/"simple.cvc")}"
     assert_match /valid/, result
+    (testpath/"simple.smt").write <<-EOS.undent
+      (set-option :produce-models true)
+      (set-logic QF_BV)
+      (define-fun s_2 () Bool false)
+      (define-fun s_1 () Bool true)
+      (assert (not s_1))
+      (check-sat)
+    EOS
+    result = shell_output "#{bin}/cvc4 --lang smt #{(testpath/"simple.smt")}"
+    assert_match /unsat/, result
   end
 end


### PR DESCRIPTION
This breaks this formula, but the formula shouldn't currently be passing its tests as it produces broken binaries on El Capitan. The bug is known by the CVC4 team, and will be fixed in their 1.5 release which is scheduled for early this month.