### PR TITLE
CUDA requirement

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -114,6 +114,7 @@ class DependencyCollector
     when :ant        then ant_dep(spec, tags)
     when :apr        then AprRequirement.new(tags)
     when :emacs      then EmacsRequirement.new(tags)
+    when :cuda       then CudaRequirement.new(tags)
     # Tiger's ld is too old to properly link some software
     when :ld64       then LD64Dependency.new if MacOS.version < :leopard
     when :python2

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -202,6 +202,12 @@ module SharedEnvExtension
     self["PATH"] = new_paths.uniq.join(File::PATH_SEPARATOR)
   end
 
+  def cuda
+    nvcc = which("nvcc")
+    self["CUDACC"] = nvcc
+    prepend_create_path "DYLD_LIBRARY_PATH", nvcc.dirname.parent/"lib"
+  end
+
   def fortran
     flags = []
 

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -13,6 +13,7 @@ require "requirements/tuntap_requirement"
 require "requirements/unsigned_kext_requirement"
 require "requirements/x11_requirement"
 require "requirements/emacs_requirement"
+require "requirements/cuda_requirement"
 
 class XcodeRequirement < Requirement
   fatal true

--- a/Library/Homebrew/requirements/cuda_requirement.rb
+++ b/Library/Homebrew/requirements/cuda_requirement.rb
@@ -1,0 +1,37 @@
+class CudaRequirement < Requirement
+  fatal true
+  cask "cuda"
+
+  def initialize(tags)
+    @version = tags.shift if /\d+\.*\d*/ === tags.first
+    super
+  end
+
+  satisfy :build_env => false do
+    next false unless which "nvcc"
+    next true unless @version
+    cuda_version = /\d\.\d/.match Utils.popen_read("nvcc", "-V")
+    Version.new(cuda_version.to_s) >= Version.new(@version)
+  end
+
+  env do
+    nvccdir = which("nvcc").dirname
+    ENV.prepend_path "PATH", nvccdir
+    ENV.prepend_create_path "DYLD_LIBRARY_PATH", nvccdir.parent/"lib"
+    ENV["CUDACC"] = "nvcc"
+  end
+
+  def message
+    if @version
+      s = "CUDA #{@version} or later is required."
+    else
+      s = "CUDA is required."
+    end
+    s += super
+    s
+  end
+
+  def inspect
+    "#<#{self.class.name}: #{name.inspect} #{tags.inspect} version=#{@version.inspect}>"
+  end
+end


### PR DESCRIPTION
Usage: `depends_on :cuda`, or `depends_on :cuda => "7.5"`. Within `test` methods, one can also use `ENV.cuda`, similarly to `ENV.fortran`.