### PR TITLE
open-scene-graph: various fixes 2015-12

### DIFF
--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -113,3 +113,16 @@ index 321cede..6497589 100644
      ENDIF()
 
  ENDIF()
+diff --git a/src/osgPlugins/dicom/CMakeLists.txt b/src/osgPlugins/dicom/CMakeLists.txt
+index 55c2a57..e6e3f4a 100644
+--- a/src/osgPlugins/dicom/CMakeLists.txt
++++ b/src/osgPlugins/dicom/CMakeLists.txt
+@@ -5,7 +5,7 @@ IF  (DCMTK_FOUND)
+
+     SET(TARGET_SRC ReaderWriterDICOM.cpp )
+
+-    LINK_LIBRARIES(${DCMTK_LIBRARIES} ${ZLIB_LIBRARY})
++    LINK_LIBRARIES(${DCMTK_LIBRARIES} iconv ${ZLIB_LIBRARY})
+
+     ADD_DEFINITIONS(-DUSE_DCMTK)
+

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -12,7 +12,6 @@ class OpenSceneGraph < Formula
     sha256 "86e946339bf8293c784e4ceb78b2ff5f203bf7166427d2e66abb462d6f03e406" => :mountain_lion
   end
 
-  option :cxx11
   option "with-docs", "Build the documentation with Doxygen and Graphviz"
   deprecated_option "docs" => "with-docs"
 
@@ -33,6 +32,8 @@ class OpenSceneGraph < Formula
   depends_on "qt5" => :optional
   depends_on "qt" => :optional
 
+  needs :cxx11
+
   # patch necessary to ensure support for gtkglext-quartz
   # filed as an issue to the developers https://github.com/openscenegraph/osg/issues/34
   patch :DATA
@@ -43,7 +44,7 @@ class OpenSceneGraph < Formula
   end
 
   def install
-    ENV.cxx11 if build.cxx11?
+    ENV.cxx11
 
     # Turning off FFMPEG takes this change or a dozen "-DFFMPEG_" variables
     if build.without? "ffmpeg"
@@ -52,6 +53,10 @@ class OpenSceneGraph < Formula
 
     args = std_cmake_args
     args << "-DBUILD_DOCUMENTATION=" + ((build.with? "docs") ? "ON" : "OFF")
+
+    # Fixes Xcode 7.1 failure due to warning in system Framework
+    # https://github.com/Homebrew/homebrew/issues/46372
+    args << "-DCMAKE_CXX_FLAGS=-Wno-c++11-narrowing"
 
     if MacOS.prefer_64_bit?
       args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.arch_64_bit}"

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -4,7 +4,7 @@ class OpenSceneGraph < Formula
   url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
   sha256 "5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e"
 
-  head "http://www.openscenegraph.org/svn/osg/OpenSceneGraph/trunk/"
+  head "https://github.com/openscenegraph/osg.git"
 
   bottle do
     sha256 "d24a9ba62fdd3d700e8c326e0ac8786229a4d84ca9786fac58b1ff8d785148ff" => :yosemite

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -62,7 +62,11 @@ class OpenSceneGraph < Formula
     end
 
     if build.with? "collada-dom"
-      args << "-DCOLLADA_INCLUDE_DIR=#{Formula["collada-dom"].opt_include}/collada-dom"
+      # https://github.com/Homebrew/homebrew/issues/43536
+      collada_include_dir = Dir.glob("#{Formula["collada-dom"].opt_include}/collada-dom*").first
+      raise "Could not locate collada-dom include directory" unless collada_include_dir
+      args << "-DCOLLADA_INCLUDE_DIR=#{collada_include_dir}"
+      args << "-DCOLLADA_DOM_ROOT=#{collada_include_dir}/1.4/dom"
     end
 
     if build.with? "qt5"


### PR DESCRIPTION
Multiple fixes to `open-scene-graph`. These fixes are unrelated, but are combined in to a single PR so they can be tested together and get a successful test run. Applying the fixes one by one results in failing tests because there are multiple outstanding issues.

Includes fixes from the following:
Closes #46401
Closes #46388
Closes #46385
Closes #46380

Fixes the following issues:
Fixes #46356
Fixes #43536
Fixes #46372

