### PR TITLE
ncutil 2.4 (new formula)

### DIFF
--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -6,10 +6,10 @@ class Ncutil < Formula
   sha256 "ebea1fe1163e401dd4e7833416001dbf9d60614237700755b55b46d0abf423bc"
 
   def install
-	bin.install "NCutil.py" => "ncutil"
+    bin.install "NCutil.py" => "ncutil"
   end
 
   test do
-	system "#{bin}/ncutil", "--help"
+    system "#{bin}/ncutil", "--help"
   end
 end

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -1,0 +1,15 @@
+class Ncutil < Formula
+  desc "Modify OS X's Notification Center: Add/remove apps, get/set alert styles, suppress notifications, etc."
+  homepage "https://github.com/jacobsalmela/NCutil"
+  url "https://github.com/jacobsalmela/NCutil/archive/2.4.tar.gz"
+  version "2.4"
+  sha256 "ebea1fe1163e401dd4e7833416001dbf9d60614237700755b55b46d0abf423bc"
+
+  def install
+	bin.install "NCutil.py" => "ncutil"
+  end
+
+  test do
+	system "#{bin}/ncutil", "--help"
+  end
+end

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -1,5 +1,5 @@
 class Ncutil < Formula
-  desc "Modify OS X's Notification Center from the command line"
+  desc "Modify OS X's Notification Center from the command-line"
   homepage "https://github.com/jacobsalmela/NCutil"
   url "https://github.com/jacobsalmela/NCutil/archive/2.4.tar.gz"
   version "2.4"

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -1,5 +1,5 @@
 class Ncutil < Formula
-  desc "Modify OS X's Notification Center: Add/remove apps, get/set alert styles, suppress notifications, etc."
+  desc "Modify OS X's Notification Center from the command line"
   homepage "https://github.com/jacobsalmela/NCutil"
   url "https://github.com/jacobsalmela/NCutil/archive/2.4.tar.gz"
   version "2.4"

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -9,6 +9,6 @@ class Ncutil < Formula
   end
 
   test do
-    system "#{bin}/ncutil", "--list"
+    system "#{bin}/ncutil", "--get-info", "com.apple.Safari"
   end
 end

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -2,7 +2,6 @@ class Ncutil < Formula
   desc "Modify OS X's Notification Center from the command-line"
   homepage "https://github.com/jacobsalmela/NCutil"
   url "https://github.com/jacobsalmela/NCutil/archive/2.4.tar.gz"
-  version "2.4"
   sha256 "ebea1fe1163e401dd4e7833416001dbf9d60614237700755b55b46d0abf423bc"
 
   def install
@@ -10,6 +9,6 @@ class Ncutil < Formula
   end
 
   test do
-    system "#{bin}/ncutil", "--help"
+    system "#{bin}/ncutil", "--list"
   end
 end

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -9,6 +9,6 @@ class Ncutil < Formula
   end
 
   test do
-    system "#{bin}/ncutil", "--get-info", "com.apple.Safari"
+    system "#{bin}/ncutil", "--get-alert-style", "com.apple.Safari"
   end
 end

--- a/Library/Formula/ncutil.rb
+++ b/Library/Formula/ncutil.rb
@@ -9,6 +9,6 @@ class Ncutil < Formula
   end
 
   test do
-    system "#{bin}/ncutil", "--get-alert-style", "com.apple.Safari"
+    system "#{bin}/ncutil", "-l"
   end
 end


### PR DESCRIPTION
Add NCutil to Homebrew.  A utility to modify OS X's Notification Center from the command line.