### PR TITLE
audit.rb: Base desc length check on short name

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -391,11 +391,12 @@ class FormulaAuditor
     end
 
     # Make sure the formula name plus description is no longer than 80 characters
-    linelength = formula.full_name.length + ": ".length + desc.length
+    # Note full_name includes the name of the tap, while name does not
+    linelength = formula.name.length + ": ".length + desc.length
     if linelength > 80
       problem <<-EOS.undent
         Description is too long. \"name: desc\" should be less than 80 characters.
-        Length is calculated as #{formula.full_name} + desc. (currently #{linelength})
+        Length is calculated as #{formula.name} + desc. (currently #{linelength})
       EOS
     end
 


### PR DESCRIPTION
Currently, brew audit --strict includes the name of the tap when calculating the
length of a formula's description. This makes it difficult to pass the audit for
formulas in taps with lengthy names. In #47033 @jawshooah called out head-only
or devel-only taps specifically, but this is an issue elsewhere. For example:

homebrew/versions/elasticsearch20: Distributed search & analytics engine (72)

This commit updates audit.rb to use formula.name rather than formula.full_name.

Closes #47033 -- Audit shouldn't include tap name in description length