### PR TITLE
z3 4.4.1: Tests and OCaml/Java bindings

### DIFF
--- a/Library/Formula/z3.rb
+++ b/Library/Formula/z3.rb
@@ -38,9 +38,7 @@ class Z3 < Formula
         system "make"
         system "make", "install"
 
-        if build.with? "ocaml"
-          (lib/"ocaml").install Dir["api/ml/*"]
-        end
+        (lib/"ocaml").install Dir["api/ml/*"] if build.with? "ocaml"
       end
     end
 

--- a/Library/Formula/z3.rb
+++ b/Library/Formula/z3.rb
@@ -5,6 +5,13 @@ class Z3 < Formula
   sha256 "50967cca12c5c6e1612d0ccf8b6ebf5f99840a783d6cf5216336a2b59c37c0ce"
   head "https://github.com/Z3Prover/z3.git"
 
+  bottle do
+    cellar :any
+    sha256 "ea169ccefdbebdd17213b4fab603dce2029b03bde0b62fa98920cbaf431d4771" => :el_capitan
+    sha256 "e8f726245f283d43efe68f2516ebf1fc62fd2ab486a850befc0c388ef9f5c1ed" => :yosemite
+    sha256 "2c67f6d604e3b478bac87e223891f3252a8f29a048564a91a8ea57f6c3b9a8ba" => :mavericks
+  end
+
   option "without-python", "Build without python 2 support"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
@@ -13,17 +20,10 @@ class Z3 < Formula
     odie "z3: --with-python3 must be specified when using --without-python"
   end
 
-  bottle do
-    cellar :any
-    sha256 "ea169ccefdbebdd17213b4fab603dce2029b03bde0b62fa98920cbaf431d4771" => :el_capitan
-    sha256 "e8f726245f283d43efe68f2516ebf1fc62fd2ab486a850befc0c388ef9f5c1ed" => :yosemite
-    sha256 "2c67f6d604e3b478bac87e223891f3252a8f29a048564a91a8ea57f6c3b9a8ba" => :mavericks
-  end
-
   def install
     inreplace "scripts/mk_util.py", "dist-packages", "site-packages"
 
-    Language::Python.each_python(build) do |python, version|
+    Language::Python.each_python(build) do |python, _|
       system python, "scripts/mk_make.py", "--prefix=#{prefix}"
       cd "build" do
         system "make"

--- a/Library/Formula/z3.rb
+++ b/Library/Formula/z3.rb
@@ -102,25 +102,5 @@ class Z3 < Formula
     if build.with? "python"
       assert_equal "#{version}\n", shell_output('python -c "import z3; print z3.get_version_string()"')
     end
-
-    if build.with? "java"
-      # Build and run the java example
-      ln_s pkgshare/"examples/java/JavaExample.java", testpath
-      system "javac", "-cp", "#{libexec}/com.microsoft.z3.jar", "JavaExample.java"
-      assert File.exist? "JavaExample.class"
-      assert_match(/Z3 Full Version: #{version}/, shell_output("java -cp #{testpath}:#{libexec}/com.microsoft.z3.jar -Djava.library.path=#{lib} JavaExample"))
-    end
-
-    if build.with? "ocaml"
-      ln_s pkgshare/"examples/ml/ml_example.ml", testpath
-      ocamlc_args = [
-        "-custom",
-        "-o", "ml_example",
-        "-cclib", "-L. -lz3",
-        "nums.cma", "z3ml.cma", "ml_example.ml",
-      ]
-      system "ocamlc", *ocamlc_args
-      assert_match(/Running Z3 version #{version}/, shell_output("./ml_example"))
-    end
   end
 end

--- a/Library/Formula/z3.rb
+++ b/Library/Formula/z3.rb
@@ -53,7 +53,7 @@ class Z3 < Formula
       s += <<-EOS.undent
 
         Java bindings were installed into #{libexec}/com.microsoft.z3.jar and #{lib}/z3java.dylib.
-    To use these, set the classpath and java.library.path accordingly.
+        To use these, set the classpath and java.library.path accordingly.
         Alternatively, you may need to link the Java bindings into the Java Extensions folder:
           sudo mkdir -p /Library/Java/Extensions
           sudo ln -s #{lib}/libz3java.dylib #{libexec}/com.microsoft.z3.jar /Library/Java/Extensions


### PR DESCRIPTION
This PR fixes some audit problems, adds more tests and adds options to build java and ocaml bindings to the Z3 SMT solver.