### PR TITLE
ttf2pt1: fix include the FreeType front-end

### DIFF
--- a/Library/Formula/ttf2pt1.rb
+++ b/Library/Formula/ttf2pt1.rb
@@ -13,7 +13,7 @@ class Ttf2pt1 < Formula
     args = %W[INSTDIR=#{prefix}]
 
     if build.with? "freetype"
-      args << "CFLAGS_FT= -DUSE_FREETYPE -I#{Formula["freetype"].include}/freetype2 -I#{prefix}/include"
+      args << "CFLAGS_FT= -DUSE_FREETYPE -I#{Formula["freetype"].include}/freetype2 -I#{include}"
       args << "LIBS_FT=-L#{Formula["freetype"].lib} -lfreetype"
     end
 

--- a/Library/Formula/ttf2pt1.rb
+++ b/Library/Formula/ttf2pt1.rb
@@ -24,6 +24,8 @@ class Ttf2pt1 < Formula
 
 end
 
+# The patch is needed to update the FreeType headers from 1.x to 2.x.
+# see http://www.freetype.org/freetype2/docs/tutorial/step1.html
 __END__
 --- /ft.c
 +++ /ft.c

--- a/Library/Formula/ttf2pt1.rb
+++ b/Library/Formula/ttf2pt1.rb
@@ -4,9 +4,43 @@ class Ttf2pt1 < Formula
   url "https://downloads.sourceforge.net/ttf2pt1/ttf2pt1-3.4.4.tgz"
   sha256 "ae926288be910073883b5c8a3b8fc168fde52b91199fdf13e92d72328945e1d0"
 
+  patch :DATA
+
+  depends_on "freetype" => :recommended
+
   def install
-    system "make", "all", "INSTDIR=#{prefix}"
+
+    args = %W[INSTDIR=#{prefix}]
+
+    if build.with? "freetype"
+      args << "CFLAGS_FT= -DUSE_FREETYPE -I#{Formula["freetype"].include}/freetype2 -I#{prefix}/include"
+      args << "LIBS_FT=-L#{Formula["freetype"].lib} -lfreetype"
+    end
+
+    system "make", "all", *args
     bin.install "ttf2pt1"
     man1.install "ttf2pt1.1"
   end
+
 end
+
+__END__
+--- /ft.c
++++ /ft.c
+@@ -12,11 +12,12 @@
+ #include <stdlib.h>
+ #include <ctype.h>
+ #include <sys/types.h>
+-#include <freetype/freetype.h>
+-#include <freetype/ftglyph.h>
+-#include <freetype/ftsnames.h>
+-#include <freetype/ttnameid.h>
+-#include <freetype/ftoutln.h>
++#include <ft2build.h>
++#include FT_FREETYPE_H
++#include FT_GLYPH_H
++#include FT_SFNT_NAMES_H
++#include FT_TRUETYPE_IDS_H
++#include FT_OUTLINE_H
+ #include "pt1.h"
+ #include "global.h"


### PR DESCRIPTION
ttf2pt1's important FreeType front-end was left out up to now. I changed the formula to include it.

The commit also includes a [necessary patch from macports](https://trac.macports.org/browser/trunk/dports/print/ttf2pt1/files/patch-ft.c?rev=144190) at the end of the formula.
