### PR TITLE
Remove build error from non-verbose failures

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -227,6 +227,8 @@ class BuildError < RuntimeError
 
   def dump
     if !ARGV.verbose?
+      onoe "#{@formula.full_name} #{@formula.version} did not build"
+      puts "View logs in #{@formula.logs}"
       puts
       puts "#{Tty.red}READ THIS#{Tty.reset}: #{Tty.em}#{OS::ISSUES_URL}#{Tty.reset}"
       if formula.tap?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1455,16 +1455,6 @@ class Formula
       $stdout.flush
 
       unless $?.success?
-        log_lines = ENV["HOMEBREW_FAIL_LOG_LINES"]
-        log_lines ||= "15"
-
-        log.flush
-        if !verbose || verbose_using_dots
-          puts "Last #{log_lines} lines from #{logfn}:"
-          Kernel.system "/usr/bin/tail", "-n", log_lines, logfn
-        end
-        log.puts
-
         require "cmd/config"
         require "build_environment"
 


### PR DESCRIPTION
The 15 lines of output is potentially very confusing for users, and this may be one of the reasons that many users miss the “READ THIS” link; the verbose output looks as though it is enough to diagnose the failure.

Instead, just provide a message saying the build failed and include the “READ THIS” link.

Ping @Homebrew/maintainers for opinions.