### PR TITLE
update url/tap for homebrew-services

### DIFF
--- a/share/doc/homebrew/External-Commands.md
+++ b/share/doc/homebrew/External-Commands.md
@@ -87,11 +87,11 @@ These commands have been contributed by Homebrew users but are not included in t
 >Scrapes a formula's homepage to get more information: [https://gist.github.com/475200](https://gist.github.com/475200)
 
 ### brew-services
->Simple support to start formulae using launchctl, has out of the box support for any formula which defines `startup_plist` (e.g. mysql, postgres, redis u.v.m.): [https://github.com/gapple/homebrew-services](https://github.com/gapple/homebrew-services)
+>Simple support to start formulae using launchctl, has out of the box support for any formula which defines `startup_plist` (e.g. mysql, postgres, redis u.v.m.): [https://github.com/Homebrew/homebrew-services](https://github.com/Homebrew/homebrew-services)
 
 > Install using:
 > ```
-  $ brew tap gapple/services
+  $ brew tap homebrew/services
 > ```
 
 ## SEE ALSO


### PR DESCRIPTION
change url from https://github.com/gapple/homebrew-services to https://github.com/Homebrew/homebrew-services
change tap from `gapple/services` to `homebrew/services`