### PR TITLE
Tty: Avoid truncating if not sensible

### DIFF
--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -9,9 +9,13 @@ class TtyTests < Homebrew::TestCase
   end
 
   def test_truncate
-    Tty.stubs(:width).returns 10
-    assert_equal "foobar", Tty.truncate("foobar something very long")
-    assert_equal "trunca", Tty.truncate("truncate")
+    Tty.stubs(:width).returns 15
+    assert_equal "foobar some", Tty.truncate("foobar something very long")
+    assert_equal "truncate", Tty.truncate("truncate")
+
+    # When the terminal is unsupported, we report 0 width
+    Tty.stubs(:width).returns 0
+    assert_equal "foobar something very long", Tty.truncate("foobar something very long")
   end
 
   def test_no_tty_formatting

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -64,7 +64,8 @@ class Tty
     end
 
     def truncate(str)
-      str.to_s[0, width - 4]
+      w = width
+      w > 10 ? str.to_s[0, w - 4] : str
     end
 
     private


### PR DESCRIPTION
This causes truncate to simply return the original string if the
terminal is not very wide, or if the terminal is unsupported.

-----

I use `rxvt-unicode-256color` for SSHing into macs, which is universally unsupported. It causes brew to output completely empty status messages because they get truncated to zero characters.

This patch attempts to address that issue without requiring the user to first find and install the correct terminfo files.

I decided that at the same time I would prevent truncate from truncating if it would have ended up with a string too short to make any sense, since this can be done in the same place and seems like sensible behaviour to me.