### PR TITLE
Apache Spark --without-hadoop flag

### DIFF
--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -5,7 +5,7 @@ class ApacheSpark < Formula
   head "https://github.com/apache/spark.git"
   bottle :unneeded
 
-  option "without-hadoop", "Use the -without-hadoop distribution of Spark (assumes you have a local installation of hadoop)"  
+  option "without-hadoop", "Use the -without-hadoop distribution of Spark (assumes you have a local installation of hadoop)"
 
   if build.without? "hadoop"
     url "https://www.apache.org/dyn/closer.lua?path=spark/spark-1.6.0/spark-1.6.0-bin-without-hadoop.tgz"
@@ -25,7 +25,7 @@ class ApacheSpark < Formula
   end
 
   test do
-    # spark-shell has a REPL-history type of thing but it needs to write 
+    # spark-shell has a REPL-history type of thing but it needs to write
     # to ~/.spark_history... not necessarily sandbox-friendly! But --driver-java-options
     # lets us pass JVM flags like -D to let us override Java/Scala system properties!
     system "#{bin}/spark-shell --driver-java-options '-Duser.home=/tmp/' <<<'sc.parallelize(1 to 1000).count()'"

--- a/Library/Formula/apache-spark.rb
+++ b/Library/Formula/apache-spark.rb
@@ -1,12 +1,19 @@
 class ApacheSpark < Formula
   desc "Engine for large-scale data processing"
   homepage "https://spark.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.6.tgz"
   version "1.6.0"
-  sha256 "439fe7793e0725492d3d36448adcd1db38f438dd1392bffd556b58bb9a3a2601"
   head "https://github.com/apache/spark.git"
-
   bottle :unneeded
+
+  option "without-hadoop", "Use the -without-hadoop distribution of Spark (assumes you have a local installation of hadoop)"  
+
+  if build.without? "hadoop"
+    url "https://www.apache.org/dyn/closer.lua?path=spark/spark-1.6.0/spark-1.6.0-bin-without-hadoop.tgz"
+    sha256 "9f62bc1d1f7668becd1fcedd5ded01ad907246df287d2525cfc562d88a3676da"
+  else
+    url "https://www.apache.org/dyn/closer.lua?path=spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.6.tgz"
+    sha256 "439fe7793e0725492d3d36448adcd1db38f438dd1392bffd556b58bb9a3a2601"
+  end
 
   def install
     # Rename beeline to distinguish it from hive's beeline
@@ -18,6 +25,9 @@ class ApacheSpark < Formula
   end
 
   test do
-    system "#{bin}/spark-shell <<<'sc.parallelize(1 to 1000).count()'"
+    # spark-shell has a REPL-history type of thing but it needs to write 
+    # to ~/.spark_history... not necessarily sandbox-friendly! But --driver-java-options
+    # lets us pass JVM flags like -D to let us override Java/Scala system properties!
+    system "#{bin}/spark-shell --driver-java-options '-Duser.home=/tmp/' <<<'sc.parallelize(1 to 1000).count()'"
   end
 end


### PR DESCRIPTION
Apache Spark has a `-without-hadoop` distribution which can sometimes be handy, such as in the case when you want to use Hadoop 2.7 features, but no `apache-spark-VER-bin-hadoop2.7` distribution exists. This patch adds a --without-hadoop option to the formula to allow installing the `-without-hadoop` dist, and also provides a slightly safer version of the existing test.