### PR TITLE
sbcl: new --with-source option

### DIFF
--- a/Library/Formula/sbcl.rb
+++ b/Library/Formula/sbcl.rb
@@ -22,6 +22,7 @@ class Sbcl < Formula
   option "without-core-compression", "Build SBCL without support for compressed cores and without a dependency on zlib"
   option "with-ldb", "Include low-level debugger in the build"
   option "with-internal-xref", "Include XREF information for SBCL internals (increases core size by 5-6MB)"
+  option "with-sources", "Install SBCL sources"
 
   # Current binary versions are listed at http://sbcl.sourceforge.net/platform-table.html
   resource "bootstrap64" do
@@ -97,6 +98,11 @@ class Sbcl < Formula
 
     ENV["INSTALL_ROOT"] = prefix
     system "sh", "install.sh"
+
+    if build.with? "sources"
+      system "cp", "-R", "contrib", prefix
+      system "cp", "-R", "src", prefix
+    end
   end
 
   test do


### PR DESCRIPTION
Please note this is only part of solution, as you'll still need to add (sb-ext:set-sbcl-source-location "/usr/local/Cellar/sbcl/1.3.2") to your local sbcl config (will require bit more time than I have ATM to fix, @ weekend most likely).