### PR TITLE
pipsi 0.9 (new formula)

### DIFF
--- a/Library/Formula/pipsi.rb
+++ b/Library/Formula/pipsi.rb
@@ -1,0 +1,43 @@
+class Pipsi < Formula
+  desc "Install python scripts with pip into isolated virtualenvs"
+  homepage "https://github.com/mitsuhiko/pipsi/"
+  url "https://pypi.python.org/packages/source/p/pipsi/pipsi-0.9.tar.gz"
+  sha256 "688b688cc8a7a76612c0d4d1839aaef98ece8382d4382b9d8b6f0caa65f0ed34"
+
+  depends_on :python if MacOS.version <= :snow_leopard
+
+  resource "click" do
+    url "https://pypi.python.org/packages/source/c/click/click-6.2.tar.gz"
+    sha256 "fba0ff70f5ebb4cebbf64c40a8fbc222fb7cf825237241e548354dabe3da6a82"
+  end
+
+  resource "virtualenv" do
+    url "https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.0.3.tar.gz"
+    sha256 "355e46928c2b00b83b7d00d70d5adc529e9c2fe1f366b07e8a1b49cd8c5bd1b9"
+  end
+
+  resource "pip" do
+    url "https://pypi.python.org/packages/source/p/pip/pip-8.0.2.tar.gz"
+    sha256 "46f4bd0d8dfd51125a554568d646fe4200a3c2c6c36b9f2d06d2212148439521"
+  end
+
+  def install
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    %w[click virtualenv pip].each do |r|
+      resource(r).stage do
+        system "python", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+    system "python", *Language::Python.setup_install_args(libexec)
+
+    bin.install Dir[libexec/"bin/*"]
+    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    system "#{bin}/pipsi", "install", "pygments"
+    system "#{bin}/pipsi", "list"
+  end
+end


### PR DESCRIPTION
pip script installer: install Python scripts with pip to their own
virtualenv to prevent cross contamination and to sandbox them

A note on the `test do` block. Currently, `pipsi` provides 4 commands:

- `install`
- `list`
- `uninstall`
- `upgrade`

The only one of these that seems suitable for a `test do` block is potentially the `list` command, although even this will be potentially uninformative. Any other command will have undesired and un-requested effects on the user's system. Unfortunately, for the time being, the `list` command crashes when nothing has been installed yet. I made the upstream aware of this in https://github.com/mitsuhiko/pipsi/issues/66 so, until this issue is resolved, the only tests I can seem to think of are simple `--help` or `--version` tests. Even when `list` comes online when nothing is installed, this doesn't seem to be more rigorous than `--version` or `--help`.