### PR TITLE
Prevent `brew deps` crash when ARGV only contains casks

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -17,9 +17,9 @@ module Homebrew
     elsif mode.all?
       puts_deps Formula
     elsif mode.tree?
-      raise FormulaUnspecifiedError if ARGV.named.empty?
+      raise FormulaUnspecifiedError if ARGV.formulae.empty?
       puts_deps_tree ARGV.formulae
-    elsif ARGV.named.empty?
+    elsif ARGV.formulae.empty?
       raise FormulaUnspecifiedError unless mode.installed?
       puts_deps Formula.installed
     else


### PR DESCRIPTION
Closes #48949