### PR TITLE
Add new Formula qwt-qt5

### DIFF
--- a/Library/Formula/qwt-qt5.rb
+++ b/Library/Formula/qwt-qt5.rb
@@ -1,0 +1,82 @@
+class QwtQt5 < Formula
+  desc "Qt Widgets for Technical Applications (for Qt5)"
+  homepage "http://qwt.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2"
+  sha256 "2b08f18d1d3970e7c3c6096d850f17aea6b54459389731d3ce715d193e243d0c"
+
+  keg_only "Qwt for Qt 5 conflicts with Qwt for Qt 4"
+
+  option "with-qwtmathml", "Build the qwtmathml library"
+  option "without-plugin", "Skip building the Qt Designer plugin"
+
+  depends_on "qt5"
+
+  # Update designer plugin linking back to qwt framework/lib after install
+  # See: https://sourceforge.net/p/qwt/patches/45/
+  patch :DATA
+
+  def install
+    inreplace "qwtconfig.pri" do |s|
+      s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
+      s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
+
+      # Install Qt plugin in `lib/qt4/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt5/\\2"
+    end
+
+    args = ["-config", "release"]
+
+    if ENV.compiler == :clang && MacOS.version >= :mavericks
+      args << "-spec" << "macx-clang"
+    else
+      args << "-spec" << "macx-g++"
+    end
+
+    if build.with? "qwtmathml"
+      args << "QWT_CONFIG+=QwtMathML"
+      prefix.install "textengines/mathml/qtmmlwidget-license"
+    end
+
+    system "#{Formula["qt5"].bin}/qmake", *args
+    system "make"
+    system "make", "install"
+  end
+
+  def caveats
+    s = ""
+
+    if build.with? "qwtmathml"
+      s += <<-EOS.undent
+        The qwtmathml library contains code of the MML Widget from the Qt solutions package.
+        Beside the Qwt license you also have to take care of its license:
+        #{opt_prefix}/qtmmlwidget-license
+      EOS
+    end
+
+    s
+  end
+end
+
+__END__
+diff --git a/designer/designer.pro b/designer/designer.pro
+index c269e9d..c2e07ae 100644
+--- a/designer/designer.pro
++++ b/designer/designer.pro
+@@ -126,6 +126,16 @@ contains(QWT_CONFIG, QwtDesigner) {
+
+     target.path = $${QWT_INSTALL_PLUGINS}
+     INSTALLS += target
++
++    macx {
++        contains(QWT_CONFIG, QwtFramework) {
++            QWT_LIB = qwt.framework/Versions/$${QWT_VER_MAJ}/qwt
++        }
++        else {
++            QWT_LIB = libqwt.$${QWT_VER_MAJ}.dylib
++        }
++        QMAKE_POST_LINK = install_name_tool -change $${QWT_LIB} $${QWT_INSTALL_LIBS}/$${QWT_LIB} $(DESTDIR)$(TARGET)
++    }
+ }
+ else {
+     TEMPLATE        = subdirs # do nothing

--- a/Library/Formula/qwt-qt5.rb
+++ b/Library/Formula/qwt-qt5.rb
@@ -56,6 +56,43 @@ class QwtQt5 < Formula
 
     s
   end
+
+  test do
+    (testpath/"hello.pro").write <<-EOS.undent
+      QT       += core
+      QT       -= gui
+      TARGET = hello
+      CONFIG   += console
+      include ( #{Formula["qwt-qt5"].bin}/../features/qwt.prf )
+      CONFIG   += qwt
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<-EOS.undent
+      #include <QCoreApplication>
+      #include <QDebug>
+      #include <QDateTime>
+      #include <qwt_date.h>
+
+      int main(int argc, char *argv[])
+      {
+        QCoreApplication a(argc, argv);
+        QDateTime now = QDateTime::currentDateTime();
+        QString week = QwtDate::toString(now, "w", QwtDate::FirstDay);
+        qDebug() << "Current week number is"
+                 << week.toStdString().c_str();
+        return 0;
+      }
+    EOS
+
+    system "#{Formula["qt5"].bin}/qmake", testpath/"hello.pro"
+    system "make"
+    assert File.exist?("hello")
+    assert File.exist?("main.o")
+    system "./hello"
+  end
 end
 
 __END__


### PR DESCRIPTION
This adds a new formula for Qwt linked against qt5.

The approach is the same used by Linux distros where Qwt linked against Qt 5 is installed to a different directory from the standard Qwt (linked against Qt 4). I also made the formula keg only but correctly linked the Qt 5 config files so that using qmake from Qt 5 will find the correct Qwt.