### PR TITLE
llvm: Fix code-signing certificate setup check

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -4,8 +4,8 @@ class CodesignRequirement < Requirement
 
   satisfy(:build_env => false) do
     mktemp do
-      touch "llvm_check.txt"
-      quiet_system "/usr/bin/codesign", "-s", "lldb_codesign", "--dryrun", "llvm_check.txt"
+      cp "/usr/bin/false", "llvm_check"
+      quiet_system "/usr/bin/codesign", "-f", "-s", "lldb_codesign", "--dryrun", "llvm_check"
     end
   end
 


### PR DESCRIPTION
The LLVM formula checks if the LLDB code signing certificate is set up correctly by trying to sign an empty text file. On certain versions of OS X, this causes codesign to segfault:

```
$ touch llvm_check.txt
$ /usr/bin/codesign -f -s lldb_codesign --dryrun llvm_check.txt
[1]    34345 segmentation fault  /usr/bin/codesign -f -s lldb_codesign --dryrun llvm_check.txt
```

 This "fixes" it in a hackish way by trying to dry-run a signing of an actual binary instead.