### PR TITLE
Fix for brew uses --recursive --installed

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -21,9 +21,7 @@ module Homebrew
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
-              if installed
-                Dependency.prune if not dep.to_formula.installed?
-              end
+              Dependency.prune if installed && !dep.to_formula.installed?
               Dependency.prune if ignores.any? { |ignore| dep.send(ignore) } && !dependent.build.with?(dep)
             end
             reqs = f.recursive_requirements do |dependent, req|

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -9,7 +9,8 @@ module Homebrew
     raise FormulaUnspecifiedError if ARGV.named.empty?
 
     used_formulae = ARGV.formulae
-    formulae = (ARGV.include? "--installed") ? Formula.installed : Formula
+    installed = ARGV.include? "--installed"
+    formulae = installed ? Formula.installed : Formula
     recursive = ARGV.flag? "--recursive"
     ignores = []
     ignores << "build?" if ARGV.include? "--skip-build"
@@ -20,6 +21,9 @@ module Homebrew
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
+              if installed
+                Dependency.prune if not dep.to_formula.installed?
+              end
               Dependency.prune if ignores.any? { |ignore| dep.send(ignore) } && !dependent.build.with?(dep)
             end
             reqs = f.recursive_requirements do |dependent, req|


### PR DESCRIPTION
```
$ brew uses harfbuzz --installed --recursive
curl            fontforge       gdal            libspatialite   wget
ffmpeg          freexl          imagemagick     pango
```

I can't find how curl for instance is linked to harbuzz. The only built optional dependency for my version of curl is openssl.

It seems there is a bug in how `--recursive` and `--installed` are taken into account:

```
$ brew uses --installed harfbuzz
pango
$ brew uses --installed pango
fontforge                                imagemagick
```

After the fix:
```
$ brew uses --installed --recursive harfbuzz
fontforge                  imagemagick                pango
```

Note:
- clean start from #49280 
- poke @ilovezfs @apjanke @mikemcquaid 