### PR TITLE
mdbm 4.12.3 (new formula)

### DIFF
--- a/Library/Formula/mdbm.rb
+++ b/Library/Formula/mdbm.rb
@@ -1,0 +1,23 @@
+class Mdbm < Formula
+  desc "super-fast memory-mapped key/value store."
+  homepage "http://yahooeng.tumblr.com/post/104861108931/mdbm-high-speed-database"
+  url "https://github.com/yahoo/mdbm/archive/v4.12.3.tar.gz"
+  sha256 "1bdd27696980b8234893f2c7bfbd0d1ad5c06ccdb1eb91bcf053db27c61eea26"
+
+  depends_on "coreutils"
+  depends_on "cppunit"
+  depends_on "readline"
+  depends_on "openssl"
+
+  def install
+    ENV.delete "CC"
+    ENV.delete "CXX"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    mdbm = "/tmp/test-brew.mdbm"
+    system "mdbm_create", mdbm
+    assert File.exist? mdbm
+  end
+end


### PR DESCRIPTION

### New Formulae Submissions:

- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?

```
 * GitHub fork (not canonical repository)
```
`yahoo/mdbm` is in fact the canonical repository. It was originally forked from an individual employee repo to a company repo.

```
 * Non-libraries were installed to "/usr/local/Cellar/mdbm/4.12.3/lib"
Installing non-libraries to "lib" is discouraged.
The offending files are:
  /usr/local/Cellar/mdbm/4.12.3/lib/libmdbm.so.4
```
These are libraries. I assume this check is firing because they're not .dylib?
