### PR TITLE
Opentsdb 2.2.0 (new formula)

### DIFF
--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -41,12 +41,12 @@ class Opentsdb < Formula
     etc.install Dir["#{opt_share}/opentsdb/etc/opentsdb"]
 
     system "#{Formula["hbase"].opt_libexec}/bin/start-hbase.sh"
-    envs = {
-      "HBASE_HOME"=>Formula["hbase"].opt_libexec.to_s,
-      "COMPRESSION"=>(build.with?("lzo") ? "LZO" : "NONE"),
-      "JAVA_HOME"=>`/usr/libexec/java_home`.strip,
-    }
-    Kernel.system(envs, "#{opt_share}/opentsdb/tools/create_table.sh")
+
+    ENV["HBASE_HOME"]=Formula["hbase"].opt_libexec.to_s
+    ENV["COMPRESSION"]=(build.with?("lzo") ? "LZO" : "NONE")
+    ENV["JAVA_HOME"]=`/usr/libexec/java_home`.strip
+    system "#{opt_share}/opentsdb/tools/create_table.sh"
+
     system "#{Formula["hbase"].opt_libexec}/bin/stop-hbase.sh"
   end
 

--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -50,9 +50,9 @@ class Opentsdb < Formula
     system "#{Formula["hbase"].opt_libexec}/bin/stop-hbase.sh"
   end
 
-  plist_options :manual => "tsdb tsd --config=#{HOMEBREW_PREFIX}/etc/opentsdb/opentsdb.conf"\
-                           "--staticroot=#{HOMEBREW_PREFIX}/opt/opentsdb/share/opentsdb/static/"\
-                           "--cachedir=#{HOMEBREW_PREFIX}/var/cache/opentsdb --port=4242"\
+  plist_options :manual => "tsdb tsd --config=#{HOMEBREW_PREFIX}/etc/opentsdb/opentsdb.conf "\
+                           "--staticroot=#{HOMEBREW_PREFIX}/opt/opentsdb/share/opentsdb/static/ "\
+                           "--cachedir=#{HOMEBREW_PREFIX}/var/cache/opentsdb --port=4242 "\
                            "--zkquorum=localhost:2181 --zkbasedir=/hbase --auto-metric"
 
   def plist; <<-EOS.undent

--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -4,9 +4,9 @@ class Opentsdb < Formula
   url "https://github.com/OpenTSDB/opentsdb/releases/download/v2.2.0/opentsdb-2.2.0.tar.gz"
   sha256 "5689d4d83ee21f1ce5892d064d6738bfa9fdef99f106f45d5c38eefb9476dfb5"
 
-  option "with-lzo", "Use LZO Compression"
+  option "without-lzo", "Don't use LZO Compression"
 
-  depends_on "hbase" unless build.with? "lzo"
+  depends_on "hbase" if build.without? "lzo"
   depends_on "hbase" => "with-lzo" if build.with? "lzo"
   depends_on :java => "1.6+"
   depends_on "gnuplot" => :optional
@@ -52,7 +52,7 @@ class Opentsdb < Formula
       confdir.install Dir["#{opt_share}/opentsdb/etc/opentsdb/*"]
     end
     system "#{hbasedir}/bin/start-hbase.sh"
-    envs = {"HBASE_HOME"=>hbasedir, "COMPRESSION"=>(build.with? 'lzo' ? "LZO":"NONE"), "JAVA_HOME"=>`/usr/libexec/java_home`.strip}
+    envs = { "HBASE_HOME"=>hbasedir, "COMPRESSION"=>(build.with?("lzo") ? "LZO" : "NONE"), "JAVA_HOME"=>`/usr/libexec/java_home`.strip }
     Kernel.system(envs, "#{opt_share}/opentsdb/tools/create_table.sh")
   end
 

--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -1,0 +1,89 @@
+class Opentsdb < Formula
+  desc "Scalable, distributed Time Series Database."
+  homepage "http://opentsdb.net/"
+  url "https://github.com/OpenTSDB/opentsdb/releases/download/v2.2.0/opentsdb-2.2.0.tar.gz"
+  sha256 "5689d4d83ee21f1ce5892d064d6738bfa9fdef99f106f45d5c38eefb9476dfb5"
+
+  depends_on "hbase"
+  depends_on :java => "1.6+"
+  depends_on "gnuplot" => :optional
+
+  def confdir
+    etc/"opentsdb"
+  end
+
+  def cachedir
+    var/"cache/opentsdb"
+  end
+
+  def install
+    inreplace "Makefile.in" do |s|
+      s.sub!(/(\$\(jar\): manifest \.javac-stamp) \$\(classes\)/, '\1')
+      s.sub!(/(echo " \$\(mkdir_p\) '\$\$dstdir'"; )/, '\1../')
+    end
+
+    mkdir "build" do
+      system "../configure",
+             "--disable-silent-rules",
+             "--prefix=#{prefix}",
+             "--mandir=#{man}"
+      system "gmake"
+      system "gmake", "install-exec-am"
+      system "gmake", "install-data-am"
+    end
+
+    confdir.mkpath
+    cachedir.mkpath
+  end
+
+  def post_install
+    unless File.exist? "#{confdir}/opentsdb.conf"
+      confdir.install Dir["#{opt_share}/opentsdb/etc/opentsdb/*"]
+    end
+    system "#{Formula["hbase"].opt_libexec.to_s}/bin/start-hbase.sh"
+    envs = {"HBASE_HOME"=>(Formula["hbase"].opt_libexec.to_s), "COMPRESSION"=>"NONE",
+            "JAVA_HOME"=>`/usr/libexec/java_home`.strip}
+    Kernel.system(envs, "#{opt_share}/opentsdb/tools/create_table.sh")
+  end
+
+  plist_options :manual => "tsdb tsd --config=#{HOMEBREW_PREFIX}/etc/opentsdb/opentsdb.conf --staticroot=#{HOMEBREW_PREFIX}/opt/opentsdb/share/opentsdb/static/ --cachedir=#{HOMEBREW_PREFIX}/var/cache/opentsdb --port=4242 --zkquorum=localhost:2181 --zkbasedir=/hbase --auto-metric"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <dict>
+        <key>OtherJobEnabled</key>
+        <string>#{Formula["hbase"].plist_name}</string>
+      </dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/tsdb</string>
+        <string>tsd</string>
+        <string>--config=#{confdir}/opentsdb.conf</string>
+        <string>--staticroot=#{opt_share}/opentsdb/static/</string>
+        <string>--cachedir=#{cachedir}</string>
+        <string>--port=4242</string>
+        <string>--zkquorum=localhost:2181</string>
+        <string>--zkbasedir=/hbase</string>
+        <string>--auto-metric</string>
+      </array>
+      <key>WorkingDirectory</key>
+      <string>#{HOMEBREW_PREFIX}</string>
+      <key>StandardOutPath</key>
+      <string>#{var}/opentsdb/opentsdb.log</string>
+      <key>StandardErrorPath</key>
+      <string>#{var}/opentsdb/opentsdb.err</string>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    system "#{bin}/tsdb", "version"
+  end
+end

--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -91,7 +91,19 @@ class Opentsdb < Formula
   end
 
   test do
+
+    cp_r (Formula["hbase"].libexec/"conf"), testpath
+    inreplace (testpath/"conf/hbase-site.xml") do |s|
+      s.gsub! /(hbase.rootdir.*)\n.*/, "\\1\n<value>file://#{testpath}/hbase</value>"
+      s.gsub! /(hbase.zookeeper.property.dataDir.*)\n.*/, "\\1\n<value>#{testpath}/zookeeper</value>"
+    end
+
+    ENV["HBASE_LOG_DIR"]  = (testpath/"logs")
+    ENV["HBASE_CONF_DIR"] = (testpath/"conf")
+    ENV["HBASE_PID_DIR"]  = (testpath/"pid")
+
     system "#{Formula["hbase"].opt_bin}/start-hbase.sh"
+    sleep 2
 
     pid = Process.spawn "#{bin}/tsdb tsd --config=#{HOMEBREW_PREFIX}/etc/opentsdb/opentsdb.conf --staticroot=#{HOMEBREW_PREFIX}/opt/opentsdb/share/opentsdb/static/ --cachedir=#{HOMEBREW_PREFIX}/var/cache/opentsdb --port=4242 --zkquorum=localhost:2181 --zkbasedir=/hbase --auto-metric"
 

--- a/Library/Formula/opentsdb.rb
+++ b/Library/Formula/opentsdb.rb
@@ -29,7 +29,9 @@ class Opentsdb < Formula
       system "../configure",
              "--disable-silent-rules",
              "--prefix=#{prefix}",
-             "--mandir=#{man}"
+             "--mandir=#{man}",
+             "--sysconfdir=#{etc}",
+             "--localstatedir=#{var}/opentsdb"
       system "make"
       system "make", "install-exec-am"
       system "make", "install-data-am"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?


I couldn't do all the requisite checking yet because this PR depends on https://github.com/Homebrew/homebrew/pull/49494 being merged first. But I wanted to get this up here because I was wondering if I could get some advice for the `post_install` clause; it throws an error when run from homebrew but not manually. Basically there's something weird with `hbase shell`'s path where it's either trying to require the pwd or somehow semi-aware of homebrew. `hbase shell` is a JRuby irb-like thing.
```
NameError: uninitialized constant Formula
  const_missing at org/jruby/RubyModule.java:2647
         (root) at ./readline.rb:1
        require at org/jruby/RubyKernel.java:1062
         (root) at ./readline.rb:10
        require at org/jruby/RubyKernel.java:1062
         (root) at /usr/local/opt/hbase/libexec/bin/../bin/hirb.rb:35
```

I'm pretty sure it's not missing something that's supposed to be there as all occurrences of `formula` in the codebase are in comments: https://github.com/apache/hbase/search?utf8=%E2%9C%93&q=Formula & https://git-wip-us.apache.org/repos/asf?p=hbase.git&a=search&h=HEAD&st=commit&s=formula

Since you guys have been dealing with ruby for longer than me, I figured you might have some ideas.