### PR TITLE
mfoc & mfcuk & libfreefare: fix <download url&sha256>

### DIFF
--- a/Library/Formula/libfreefare.rb
+++ b/Library/Formula/libfreefare.rb
@@ -2,7 +2,7 @@ class Libfreefare < Formula
   desc "API for MIFARE card manipulations"
   homepage "https://github.com/nfc-tools/libfreefare/"
   url "https://github.com/nfc-tools/libfreefare/releases/download/libfreefare-0.4.0/libfreefare-0.4.0.tar.bz2"
-  sha256 "BFA31D14A99A1247F5ED49195D6373DE512E3EB75BF1627658B40CF7F876BC64"
+  sha256 "bfa31d14a99a1247f5ed49195d6373de512e3eb75bf1627658b40cf7f876bc64"
   revision 1
 
   bottle do

--- a/Library/Formula/libfreefare.rb
+++ b/Library/Formula/libfreefare.rb
@@ -1,8 +1,8 @@
 class Libfreefare < Formula
   desc "API for MIFARE card manipulations"
-  homepage "https://code.google.com/p/libfreefare/"
-  url "https://libfreefare.googlecode.com/files/libfreefare-0.4.0.tar.bz2"
-  sha256 "bfa31d14a99a1247f5ed49195d6373de512e3eb75bf1627658b40cf7f876bc64"
+  homepage "https://github.com/nfc-tools/libfreefare/"
+  url "https://github.com/nfc-tools/libfreefare/releases/download/libfreefare-0.4.0/libfreefare-0.4.0.tar.bz2"
+  sha256 "BFA31D14A99A1247F5ED49195D6373DE512E3EB75BF1627658B40CF7F876BC64"
   revision 1
 
   bottle do

--- a/Library/Formula/mfcuk.rb
+++ b/Library/Formula/mfcuk.rb
@@ -1,8 +1,8 @@
 class Mfcuk < Formula
   desc "MiFare Classic Universal toolKit"
-  homepage "https://code.google.com/p/mfcuk/"
-  url "https://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz"
-  sha256 "977595765b4b46e4f47817e9500703aaf5c1bcad39cb02661f862f9d83f13a55"
+  homepage "https://github.com/nfc-tools/mfcuk"
+  url "https://github.com/nfc-tools/mfcuk/archive/mfcuk-0.3.8.tar.gz"
+  sha256 "C7091D1A16B132E1A4917EBC705065B60F3D1A0B449A776411BA39612A62EE89"
 
   depends_on "pkg-config" => :build
   depends_on "libnfc"

--- a/Library/Formula/mfcuk.rb
+++ b/Library/Formula/mfcuk.rb
@@ -2,7 +2,7 @@ class Mfcuk < Formula
   desc "MiFare Classic Universal toolKit"
   homepage "https://github.com/nfc-tools/mfcuk"
   url "https://github.com/nfc-tools/mfcuk/archive/mfcuk-0.3.8.tar.gz"
-  sha256 "C7091D1A16B132E1A4917EBC705065B60F3D1A0B449A776411BA39612A62EE89"
+  sha256 "c7091d1a16b132e1a4917ebc705065b60f3d1a0b449a776411ba39612a62ee89"
 
   depends_on "pkg-config" => :build
   depends_on "libnfc"

--- a/Library/Formula/mfoc.rb
+++ b/Library/Formula/mfoc.rb
@@ -2,7 +2,7 @@ class Mfoc < Formula
   desc "Implementation of 'offline nested' attack by Nethemba"
   homepage "https://github.com/nfc-tools/mfoc"
   url "https://github.com/nfc-tools/mfoc/archive/mfoc-0.10.7.tar.gz"
-  sha256 "2DFD8FFA4A8B357807680D190A91C8CF3DB54B4211A781EDC1108AF401DBAAD7"
+  sha256 "2dfd8ffa4a8b357807680d190a91c8cf3db54b4211a781edc1108af401dbaad7"
 
   depends_on "pkg-config" => :build
   depends_on "libnfc"

--- a/Library/Formula/mfoc.rb
+++ b/Library/Formula/mfoc.rb
@@ -1,8 +1,8 @@
 class Mfoc < Formula
   desc "Implementation of 'offline nested' attack by Nethemba"
-  homepage "https://code.google.com/p/mfoc/"
-  url "https://mfoc.googlecode.com/files/mfoc-0.10.7.tar.bz2"
-  sha256 "93d8ac4cb0aa6ed94855ca9732a2ffd898a9095c087f12f9402205443c2eb98c"
+  homepage "https://github.com/nfc-tools/mfoc"
+  url "https://github.com/nfc-tools/mfoc/archive/mfoc-0.10.7.tar.gz"
+  sha256 "2DFD8FFA4A8B357807680D190A91C8CF3DB54B4211A781EDC1108AF401DBAAD7"
 
   depends_on "pkg-config" => :build
   depends_on "libnfc"


### PR DESCRIPTION
due to the Google Code Project will be turned down in early 2016.
https://code.google.com/archive/p/nfc-tools/ has moved to https://github.com/nfc-tools/
this pull request modify the download url and sha256  of the nfc tools