### PR TITLE
cegui 0.8.4 (new formula)

### DIFF
--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -39,15 +39,14 @@ class Cegui < Formula
       system "cat", "test.cpp"
 
       cc_args = []
-      cc_args << "-E"
+      # cc_args << "-E"
       cc_args << "-DCEGUI_OPENGLRENDERER_EXPORTS"
       cc_args << "-Icegui/include"
       cc_args << "-I../cegui/include"
       cc_args << "-I/usr/local/include"
       cc_args << "-F#{MacOS.sdk_path}/System/Library/Frameworks"
       cc_args << "-DNDEBUG"
-      # cc_args << "-arch x86_64"
-      cc_args << "-isysroot#{MacOS.sdk_path}"
+      cc_args << "-isysroot #{MacOS.sdk_path}"
       cc_args << "-fPIC"
       cc_args << "-c"
       cc_args << "test.cpp"

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -37,7 +37,7 @@ class Cegui < Formula
         return (804u <= vnum) ? 0 : 1;
       }
     EOS
-    system ENV.cc, "test.cpp", "-I#{prefix}/include/cegui-0", "-L#{lib}", "-lCEGUIBase-0", "-o", "test"
+    system ENV.cc, "test.cpp", "-I#{include}/cegui-0", "-L#{lib}", "-lCEGUIBase-0", "-o", "test"
     system "./test"
   end
 end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -1,0 +1,54 @@
+class Cegui < Formula
+  desc " provides windowing and widget toolkits for GL and other APIs"
+  homepage "http://cegui.org.uk/"
+  url "https://bitbucket.org/cegui/cegui/get/v0-8-4.tar.gz"
+  version "0.8.5"
+  sha256 "a435a170e3ca6cca4a32ce369e12d803757264dd0d064935d7b9b4f69c8832a8"
+
+  head do
+    url "https://bitbucket.org/cegui/cegui", :using => :hg, :branch => "v0-8"
+  end
+
+  # TODO: Try python option again when CEGUI issue #1114 is resolved
+  #       https://bitbucket.org/cegui/cegui/issues/1114/
+  #       requires boost-python also
+  # option "with-python", "Build python bindings also, needed for certain apps"
+
+  depends_on "cmake" => :build
+  depends_on "glm" => :build
+  # In 0.8.5 we should switch from GLEW to libepoxy, or, make an option
+  depends_on "glew"
+  depends_on "freeimage"
+  depends_on "freetype"
+  depends_on "pcre"
+  depends_on "expat" if OS.linux?
+
+  def install
+    mkdir "build"
+    cd "build"
+
+    # TODO: Enable fribidi after build problems are fixed
+    cegui_opts = %w[-DCEGUI_SAMPLES_ENABLED=0 -DCEGUI_USE_FRIBIDI=0 -DCEGUI_BUILD_DATAFILE_TESTS=1]
+    cegui_opts << "-DCEGUI_BUILD_DATAFILE_TESTS=1"
+    cegui_opts << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
+
+    if build.with? "python"
+      cegui_opts << '-DBOOST_ROOT=#{Formula["boost"].opt_prefix}'
+      cegui_opts << "-DBoost_DEBUG=1"
+      cegui_opts << "-DBoost_DETAILED_FAILURE_MSG=1"
+      cegui_opts << "-DCEGUI_BUILD_PYTHON_MODULES=1"
+    else
+      cegui_opts << "-DCEGUI_BUILD_PYTHON_MODULES=0"
+    end
+
+    system "cmake", "..", *std_cmake_args, *cegui_opts
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    cd "#{prefix}/cegui/build"
+    system "CEGUI_SAMPLE_DATAPATH=`pwd`/../datafiles", "ctest", "-V"
+  end
+end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -5,9 +5,7 @@ class Cegui < Formula
   version "0.8.4"
   sha256 "a435a170e3ca6cca4a32ce369e12d803757264dd0d064935d7b9b4f69c8832a8"
 
-  head do
-    url "https://bitbucket.org/cegui/cegui", :using => :hg, :branch => "v0-8"
-  end
+  head "https://bitbucket.org/cegui/cegui", :using => :hg, :branch => "v0-8"
 
   depends_on "cmake" => :build
   depends_on "glm" => :build
@@ -20,7 +18,6 @@ class Cegui < Formula
     # TODO: Enable fribidi after build problems are fixed
     args = std_cmake_args
     args << "-DCEGUI_SAMPLES_ENABLED=0"
-    args << "-DCEGUI_BUILD_DATAFILE_TESTS=1"
     args << "-DCEGUI_USE_FRIBIDI=0"
     args << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
     args << "-DCEGUI_BUILD_PYTHON_MODULES=0"
@@ -33,7 +30,14 @@ class Cegui < Formula
   end
 
   test do
-    testpath = "#{prefix}/cegui/build"
-    system "CEGUI_SAMPLE_DATAPATH=`pwd`/../datafiles", "ctest", "-V"
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <CEGUI/CEGUI.h>
+      int main() {
+        unsigned int vnum = 10000 * CEGUI_VERSION_MAJOR + 100 * CEGUI_VERSION_MINOR + CEGUI_VERSION_PATCH;
+        return (804u <= vnum) ? 0 : 1;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-I#{prefix}/include/cegui-0", "-L#{lib}", "-lCEGUIBase-0", "-o", "test"
+    system "./test"
   end
 end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -24,6 +24,8 @@ class Cegui < Formula
     args << "-DCEGUI_BUILD_PYTHON_MODULES=0"
 
     mkdir "build" do
+      system "cat", "#{MacOS.sdk_path}/System/Library/Frameworks/OpenGL.framework/Headers/CGLTypes.h"
+      system "cat", "#{MacOS.sdk_path}/System/Library/Frameworks/OpenGL.framework/Headers/OpenGLAvailability.h"
       system "cmake", "..", *args
       system "make"
       system "make", "install"

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -19,8 +19,9 @@ class Cegui < Formula
   def install
     # TODO: Enable fribidi after build problems are fixed
     args = std_cmake_args
-    args += %w[-DCEGUI_SAMPLES_ENABLED=0 -DCEGUI_USE_FRIBIDI=0 -DCEGUI_BUILD_DATAFILE_TESTS=1]
+    args << "-DCEGUI_SAMPLES_ENABLED=0"
     args << "-DCEGUI_BUILD_DATAFILE_TESTS=1"
+    args << "-DCEGUI_USE_FRIBIDI=0"
     args << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
     args << "-DCEGUI_BUILD_PYTHON_MODULES=0"
 

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -38,7 +38,7 @@ class Cegui < Formula
       cc_args << "-F#{MacOS.sdk_path}/System/Library/Frameworks"
       cc_args << "-DNDEBUG"
       cc_args << "-arch x86_64"
-      cc_args << "-isysroot#{MacOS.sdk_path}"
+      cc_args << "-isysroot #{MacOS.sdk_path}"
       cc_args << "-fPIC"
       cc_args << "-c"
       cc_args << "../cegui/src/RendererModules/OpenGL/ApplePBTextureTarget.cpp"

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -24,10 +24,26 @@ class Cegui < Formula
     args << "-DCEGUI_BUILD_PYTHON_MODULES=0"
 
     mkdir "build" do
-      system "cat", "#{MacOS.sdk_path}/System/Library/Frameworks/OpenGL.framework/Headers/CGLTypes.h"
       system "cat", "#{MacOS.sdk_path}/System/Library/Frameworks/OpenGL.framework/Headers/OpenGLAvailability.h"
+      system "cat", "#{MacOS.sdk_path}/System/Library/Frameworks/OpenGL.framework/Headers/CGLTypes.h"
+
       system "cmake", "..", *args
+
       system "make"
+
+      cc_args = []
+      cc_args << "-E"
+      cc_args << "-DCEGUI_OPENGLRENDERER_EXPORTS"
+      cc_args << "-Icegui/include"
+      cc_args << "-I../cegui/include"
+      cc_args << "-I/usr/local/include"
+      cc_args << "-F#{MacOS.sdk_path}/System/Library/Frameworks"
+      cc_args << "-DNDEBUG"
+      cc_args << "-arch x86_64"
+      cc_args << "-isysroot#{MacOS.sdk_path}"
+      cc_args << "-fPIC"
+      system ENV.cc, *cc_args, "-c", "../cegui/src/RendererModules/OpenGL/ApplePBTextureTarget.cpp"
+
       system "make", "install"
     end
   end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -17,6 +17,7 @@ class Cegui < Formula
   def install
     # TODO: Enable fribidi after build problems are fixed
     args = std_cmake_args
+    args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}"
     args << "-DCEGUI_SAMPLES_ENABLED=0"
     args << "-DCEGUI_USE_FRIBIDI=0"
     args << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
@@ -33,8 +34,11 @@ class Cegui < Formula
     (testpath/"test.cpp").write <<-EOS.undent
       #include <CEGUI/CEGUI.h>
       int main() {
-        unsigned int vnum = 10000 * CEGUI_VERSION_MAJOR + 100 * CEGUI_VERSION_MINOR + CEGUI_VERSION_PATCH;
-        return (804u <= vnum) ? 0 : 1;
+        unsigned int vnum = 10000u * CEGUI::System::getMajorVersion()
+                          +   100u * CEGUI::System::getMinorVersion()
+                          +          CEGUI::System::getPatchVersion();
+
+        if (804u > vnum) { return 1; }
       }
     EOS
     system ENV.cc, "test.cpp", "-I#{include}/cegui-0", "-L#{lib}", "-lCEGUIBase-0", "-o", "test"

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -29,6 +29,13 @@ class Cegui < Formula
 
       system "cmake", "..", *args
 
+      (buildpath/"build/test.cpp").write <<-EOS.undent
+        #include <OpenGL/OpenGL.h>
+        int main() {}
+      EOS
+
+      system "cat", "test.cpp"
+
       cc_args = []
       cc_args << "-E"
       cc_args << "-DCEGUI_OPENGLRENDERER_EXPORTS"
@@ -38,10 +45,10 @@ class Cegui < Formula
       cc_args << "-F#{MacOS.sdk_path}/System/Library/Frameworks"
       cc_args << "-DNDEBUG"
       cc_args << "-arch x86_64"
-      cc_args << "-isysroot #{MacOS.sdk_path}"
+      cc_args << "-isysroot#{MacOS.sdk_path}"
       cc_args << "-fPIC"
       cc_args << "-c"
-      cc_args << "../cegui/src/RendererModules/OpenGL/ApplePBTextureTarget.cpp"
+      cc_args << "test.cpp"
       system ENV.cc, *cc_args
 
       system "make"

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -29,8 +29,6 @@ class Cegui < Formula
 
       system "cmake", "..", *args
 
-      system "make"
-
       cc_args = []
       cc_args << "-E"
       cc_args << "-DCEGUI_OPENGLRENDERER_EXPORTS"
@@ -42,8 +40,11 @@ class Cegui < Formula
       cc_args << "-arch x86_64"
       cc_args << "-isysroot#{MacOS.sdk_path}"
       cc_args << "-fPIC"
-      system ENV.cc, *cc_args, "-c", "../cegui/src/RendererModules/OpenGL/ApplePBTextureTarget.cpp"
+      cc_args << "-c"
+      cc_args << "../cegui/src/RendererModules/OpenGL/ApplePBTextureTarget.cpp"
+      system ENV.cc, *cc_args
 
+      system "make"
       system "make", "install"
     end
   end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -1,54 +1,38 @@
 class Cegui < Formula
-  desc " provides windowing and widget toolkits for GL and other APIs"
+  desc "provides windowing and widget toolkits for GL and other APIs"
   homepage "http://cegui.org.uk/"
   url "https://bitbucket.org/cegui/cegui/get/v0-8-4.tar.gz"
-  version "0.8.5"
+  version "0.8.4"
   sha256 "a435a170e3ca6cca4a32ce369e12d803757264dd0d064935d7b9b4f69c8832a8"
 
   head do
     url "https://bitbucket.org/cegui/cegui", :using => :hg, :branch => "v0-8"
   end
 
-  # TODO: Try python option again when CEGUI issue #1114 is resolved
-  #       https://bitbucket.org/cegui/cegui/issues/1114/
-  #       requires boost-python also
-  # option "with-python", "Build python bindings also, needed for certain apps"
-
   depends_on "cmake" => :build
   depends_on "glm" => :build
-  # In 0.8.5 we should switch from GLEW to libepoxy, or, make an option
   depends_on "glew"
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "pcre"
-  depends_on "expat" if OS.linux?
 
   def install
-    mkdir "build"
-    cd "build"
-
     # TODO: Enable fribidi after build problems are fixed
-    cegui_opts = %w[-DCEGUI_SAMPLES_ENABLED=0 -DCEGUI_USE_FRIBIDI=0 -DCEGUI_BUILD_DATAFILE_TESTS=1]
-    cegui_opts << "-DCEGUI_BUILD_DATAFILE_TESTS=1"
-    cegui_opts << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
+    args = std_cmake_args
+    args += %w[-DCEGUI_SAMPLES_ENABLED=0 -DCEGUI_USE_FRIBIDI=0 -DCEGUI_BUILD_DATAFILE_TESTS=1]
+    args << "-DCEGUI_BUILD_DATAFILE_TESTS=1"
+    args << "-DCEGUI_BUILD_RENDERER_OPENGL3=1"
+    args << "-DCEGUI_BUILD_PYTHON_MODULES=0"
 
-    if build.with? "python"
-      cegui_opts << '-DBOOST_ROOT=#{Formula["boost"].opt_prefix}'
-      cegui_opts << "-DBoost_DEBUG=1"
-      cegui_opts << "-DBoost_DETAILED_FAILURE_MSG=1"
-      cegui_opts << "-DCEGUI_BUILD_PYTHON_MODULES=1"
-    else
-      cegui_opts << "-DCEGUI_BUILD_PYTHON_MODULES=0"
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
+      system "make", "install"
     end
-
-    system "cmake", "..", *std_cmake_args, *cegui_opts
-
-    system "make"
-    system "make", "install"
   end
 
   test do
-    cd "#{prefix}/cegui/build"
+    testpath = "#{prefix}/cegui/build"
     system "CEGUI_SAMPLE_DATAPATH=`pwd`/../datafiles", "ctest", "-V"
   end
 end

--- a/Library/Formula/cegui.rb
+++ b/Library/Formula/cegui.rb
@@ -15,6 +15,8 @@ class Cegui < Formula
   depends_on "pcre"
 
   def install
+    inreplace "CMakeLists.txt", "CMAKE_OSX_ARCHITECTURES", "IGNORED"
+
     # TODO: Enable fribidi after build problems are fixed
     args = std_cmake_args
     args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}"
@@ -44,7 +46,7 @@ class Cegui < Formula
       cc_args << "-I/usr/local/include"
       cc_args << "-F#{MacOS.sdk_path}/System/Library/Frameworks"
       cc_args << "-DNDEBUG"
-      cc_args << "-arch x86_64"
+      # cc_args << "-arch x86_64"
       cc_args << "-isysroot#{MacOS.sdk_path}"
       cc_args << "-fPIC"
       cc_args << "-c"


### PR DESCRIPTION
There are a few TODO items -- it would be really nice if we could
build the python modules associated to CEGUI, but due to a bug,
which is currently blocking 0.8.5 release, it can't be accomplished
with current versions of boost python.

When 0.8.5 is released, I would like to add the python bindings
option to this formula, and then use it as a dependency to build
CEED, a layout editor tool for CEGUI which would be really convenient
to have installed via homebrew.