### PR TITLE
audit: check plist placement

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -187,6 +187,7 @@ class FormulaAuditor
       [/^  (go_)?resource/,                "resource"],
       [/^  def install/,                   "install method"],
       [/^  def caveats/,                   "caveats method"],
+      [/^  (plist_options|def plist)/,     "plist block"],
       [/^  test do/,                       "test block"],
     ]
 

--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -173,6 +173,24 @@ class FormulaAuditorTests < Homebrew::TestCase
       fa.problems
   end
 
+  def test_audit_file_strict_plist_placement
+    fa = formula_auditor "foo", <<-EOS.undent, :strict => true
+      class Foo < Formula
+        url "https://example.com/foo-1.0.tgz"
+
+        test do
+          assert_match "Dogs are terrific", shell_output("./dogs")
+        end
+
+        def plist
+        end
+      end
+    EOS
+    fa.audit_file
+    assert_equal ["`plist block` (line 8) should be put before `test block` (line 4)"],
+      fa.problems
+  end
+
   def test_audit_file_strict_url_outside_of_stable_block
     fa = formula_auditor "foo", <<-EOS.undent, :strict => true
       class Foo < Formula


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

Was highlighted to me that our audit currently completely ignores `plist`s despite checking for almost everything else possible written into a formula. Makes sense to add that check. It doesn't cover 100% but it covers the most common two cases and preferred names for those blocks.