### PR TITLE
nanomsgxx 0.1 (new formula)

### DIFF
--- a/Library/Formula/nanomsgxx.rb
+++ b/Library/Formula/nanomsgxx.rb
@@ -7,7 +7,7 @@ class Nanomsgxx < Formula
   option "with-debug", "Compile with debug symbols"
 
   depends_on "pkg-config" => :build
-  depends_on :python
+  depends_on :python => :build if MacOS.version <= :snow_leopard
 
   if build.with? "debug"
     depends_on "nanomsg" => "with-debug"
@@ -30,13 +30,15 @@ class Nanomsgxx < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<-EOS
-#include <iostream>\nint main(int argc, char **argv) {\n\tstd::cout << "Hello Nanomsgxx!" << std::endl;\n}
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <iostream>
+      int main(int argc, char **argv) {
+        std::cout << "Hello Nanomsgxx!" << std::endl;
+      }
     EOS
 
-    system "c++", "-std=c++11", "-lnnxx", "test.cpp"
+    system ENV.cxx, "-std=c++11", "-lnnxx", "test.cpp"
 
-    assert_equal "Hello Nanomsgxx!\n",
-        shell_output("#{testpath}/a.out")
+    assert_equal "Hello Nanomsgxx!\n", shell_output("#{testpath}/a.out")
   end
 end

--- a/Library/Formula/nanomsgxx.rb
+++ b/Library/Formula/nanomsgxx.rb
@@ -1,0 +1,42 @@
+class Nanomsgxx < Formula
+  desc "Nanomsg binding for C++11"
+  homepage "https://achille-roussel.github.io/nanomsgxx/doc/nanomsgxx.7.html"
+  url "https://github.com/achille-roussel/nanomsgxx/archive/0.1.tar.gz"
+  sha256 "50f6d2507f264f048e0234e78bbbfe80004d636d990fefc4e1f53a5434c4aa63"
+
+  option "with-debug", "Compile with debug symbols"
+
+  depends_on "pkg-config" => :build
+  depends_on :python
+
+  if build.with? "debug"
+    depends_on "nanomsg" => "with-debug"
+  else
+    depends_on "nanomsg"
+  end
+
+  def install
+    args = %W[
+      --static
+      --shared
+      --prefix=#{prefix}
+    ]
+
+    args << "--debug" if build.with? "debug"
+
+    system "python", "./waf", "configure", *args
+    system "python", "./waf", "build"
+    system "python", "./waf", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS
+#include <iostream>\nint main(int argc, char **argv) {\n\tstd::cout << "Hello Nanomsgxx!" << std::endl;\n}
+    EOS
+
+    system "c++", "-std=c++11", "-lnnxx", "test.cpp"
+
+    assert_equal "Hello Nanomsgxx!\n",
+        shell_output("#{testpath}/a.out")
+  end
+end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [x] Have you successfully ran `brew tests` with your changes locally?

### Description of nanomsgxx

nanomsgxx aims to provide a very thin abstraction on top of the nanomsg C API, while taking advantage of C++11's features to make the code easier to read and write.

Despite the version number, [according to the author](https://github.com/achille-roussel/nanomsgxx/releases), this is a stable release.
> This is the first release of nanomsgxx, it's mostly stable as it's known to be used by a bunch of people. While this is not a 1.x version it's really unlikely that breaking changes will be brought to the API.

### Known Audit Problems

 * GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)
