### PR TITLE
libmpdec 2.4.2 (new formula)

### DIFF
--- a/Library/Formula/libmpdec.rb
+++ b/Library/Formula/libmpdec.rb
@@ -1,0 +1,45 @@
+class Libmpdec < Formula
+  desc "Library for arbitrary precision decimal floating point arithmetic."
+  homepage "http://www.bytereef.org/mpdecimal/index.html"
+  url "http://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.4.2.tar.gz"
+  sha256 "83c628b90f009470981cf084c5418329c88b19835d8af3691b930afccb7d79c7"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <assert.h>
+      #include <mpdecimal.h>
+
+      int main()
+      {
+        mpd_context_t ctx;
+        mpd_t *a, *b, *result;
+        mpd_defaultcontext(&ctx);
+
+        result = mpd_new(&ctx);
+        a = mpd_new(&ctx);
+        b = mpd_new(&ctx);
+
+        mpd_set_string(a, "0.1234", &ctx);
+        mpd_set_string(b, "0.12340000", &ctx);
+
+        mpd_compare(result, a, b, &ctx);
+        int r = mpd_get_i32(result, &ctx);
+        assert(r == 0);
+
+        mpd_del(a);
+        mpd_del(b);
+        mpd_del(result);
+
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lmpdec", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Upstream has accepted the patch and rolled a new release, so libmpdec no longer requires any patches.

Hopefully it can be accepted into homebrew now after two failed attempts #46545 & #48557 

The audit brings up a warning
>Installing non-libraries to "lib" is discouraged.
>The offending files are:
>  /usr/local/Cellar/libmpdec/2.4.2/lib/libmpdec.so.2
>  /usr/local/Cellar/libmpdec/2.4.2/lib/libmpdec.so.2.4.2

However I think this should be disregarded since it must certainly is a library even though it's named .so and not .dylib - and works perfectly. Other ports also install .so files.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?