### PR TITLE
rtl_433 0.01 (new formula)

### DIFF
--- a/Library/Formula/rtl_433.rb
+++ b/Library/Formula/rtl_433.rb
@@ -1,13 +1,14 @@
 class Rtl433 < Formula
   desc "Tool to talk to 433Mhz devices using RTL devices"
   homepage "https://github.com/merbanan/rtl_433"
-  url "https://github.com/merbanan/rtl_433.git", :revision => "922a76a81820c68e2e5c55a428e5d22135a8be9a"
+  url "https://github.com/merbanan/rtl_433/archive/0.01.tar.gz"
+  sha256 "10f29c0ea91684f91f42537cf2498b1236411ab2c48893f2d139126ad4e000e5"
+  head "https://github.com/merbanan/rtl_433.git"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "libtool"  => :build
-
   depends_on "librtlsdr"
 
   def install
@@ -15,5 +16,9 @@ class Rtl433 < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
+  end
+
+  test do
+    system "#{bin}/rtl_433", "-h"
   end
 end

--- a/Library/Formula/rtl_433.rb
+++ b/Library/Formula/rtl_433.rb
@@ -17,8 +17,4 @@ class Rtl433 < Formula
     system "make"
     system "make", "install"
   end
-
-  test do
-    system "#{bin}/rtl_433", "-h"
-  end
 end

--- a/Library/Formula/rtl_433.rb
+++ b/Library/Formula/rtl_433.rb
@@ -1,0 +1,19 @@
+class Rtl433 < Formula
+  desc "Tool to talk to 433Mhz devices using RTL devices"
+  homepage "https://github.com/merbanan/rtl_433"
+  url "https://github.com/merbanan/rtl_433.git", :revision => "922a76a81820c68e2e5c55a428e5d22135a8be9a"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libtool"  => :build
+
+  depends_on "librtlsdr"
+
+  def install
+    system "autoreconf", "--install"
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing]
(https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
Yes
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?
Yes

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [ ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
Yes
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?
Yes

### Changes to Homebrew's Core:



RTL 433 is a tool that uses librtlsdr to talk to 433Mhz
wireless devices such as weather stations, wireless alarms,
wireless doorbells...