### PR TITLE
Add echo to brew update, so users don't think it's hanging

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -252,6 +252,8 @@ homebrew-update() {
   local option
   local DIR
   local UPSTREAM_BRANCH
+  
+  echo "brew updating. This may take some time."
 
   for option in "$@"
   do


### PR DESCRIPTION
I propose that we print a warning along the lines of "This may take some time." after starting the brew update process.

A few days ago I ran brew update after several months of not using brew and it took more than 10 minutes to complete.
I assumed it was hanging and almost gave up and reinstalled brew until I noticed that the process was slamming my network with update information.

I think any user-facing process like this should warn the user if it can take more than a few seconds to complete, mostly so the user doesn't think (as I did) that the process isn't working.

My commit might not be right, since I'm not that familiar with brew's core, but I provide it as an option if it looks good.