### PR TITLE
update: improve output in debug/verbose mode

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -6,6 +6,8 @@ require "descriptions"
 
 module Homebrew
   def update_report
+    oh1 "Homebrew update report" if ARGV.verbose?
+
     # migrate to new directories based tap structure
     migrate_taps
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -177,6 +177,8 @@ pull() {
   INITIAL_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)"
   UPSTREAM_BRANCH="$(upstream_branch)"
 
+  [[ -n "$HOMEBREW_VERBOSE" ]] && ohai "Updating $DIR"
+
   # Used for testing purposes, e.g., for testing formula migration after
   # renaming it in the currently checked-out branch. To test run
   # "brew update --simulate-from-current-branch"
@@ -321,6 +323,8 @@ EOS
   # this procedure will be removed in the future if it seems unnecessary
   rename_taps_dir_if_necessary
 
+  [[ -n "$HOMEBREW_VERBOSE" ]] && oh1 "Fetching updates for all Git repositories"
+
   # kill all of subprocess on interrupt
   trap '{ pkill -P $$; wait; exit 130; }' SIGINT
 
@@ -357,6 +361,8 @@ EOS
 
   wait
   trap - SIGINT
+
+  [[ -n "$HOMEBREW_VERBOSE" ]] && oh1 "Updating all Git repositories"
 
   for DIR in "$HOMEBREW_REPOSITORY" "$HOMEBREW_LIBRARY"/Taps/*/*
   do

--- a/Library/Homebrew/utils.sh
+++ b/Library/Homebrew/utils.sh
@@ -1,0 +1,47 @@
+puts_with_style() {
+  local message output_fd="$1" plain="$2" styled="$3"
+  shift 3
+
+  if [[ $# -eq 0 ]]
+  then
+    IFS= read -d '' -r message # Read message from `stdin`.
+    message="${message%$'\n'}" # Trim trailing newline.
+  else
+    message="$*"
+  fi
+
+  if [[ -t "$output_fd" ]] # If FD is a TTY, style message with color/bold/...
+  then
+    # shellcheck disable=SC2059
+    printf "$styled\n" "$message"
+  else
+    # shellcheck disable=SC2059
+    printf "$plain\n" "$message"
+  fi
+}
+
+ohai() {
+  # Use bold and blue color if `stdout` is a TTY.
+  puts_with_style 1 "==> %s" "\033[1;34m==>\033[1;39m %s\033[0m" "$@"
+}
+
+oh1() {
+  # Use bold and green color if `stdout` is a TTY.
+  puts_with_style 1 "==> %s" "\033[1;32m==>\033[1;39m %s\033[0m" "$@"
+}
+
+opoo() {
+  # Use underline and yellow color if `stderr` is a TTY.
+  puts_with_style 2 "Warning: %s" "\033[4;33mWarning\033[0m: %s" "$@" >&2
+}
+
+onoe() {
+  # Use underline and red color if `stderr` is a TTY.
+  puts_with_style 2 "Error: %s" "\033[4;31mError\033[0m: %s" "$@" >&2
+}
+
+odie() {
+  # Use underline and red color if `stderr` is a TTY.
+  puts_with_style 2 "Error: %s" "\033[4;31mError\033[0m: %s" "$@" >&2
+  exit 1
+}

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -1,20 +1,7 @@
 HOMEBREW_VERSION="0.9.5"
 
-odie() {
-  if [[ -t 2 ]] # check whether stderr is a tty.
-  then
-    echo -ne "\033[4;31mError\033[0m: " >&2 # highlight Error with underline and red color
-  else
-    echo -n "Error: " >&2
-  fi
-  if [[ $# -eq 0 ]]
-  then
-    /bin/cat >&2
-  else
-    echo "$*" >&2
-  fi
-  exit 1
-}
+# shellcheck source=/dev/null
+source "$HOMEBREW_LIBRARY/Homebrew/utils.sh"
 
 chdir() {
   cd "$@" >/dev/null || odie "Error: failed to cd to $*!"


### PR DESCRIPTION
Running `brew update --verbose`, particularly with many taps, currently produces a gibberish of intermixed output due to parallel fetching (See [update-v-parallel.txt](https://gist.github.com/UniqMartin/e63898f3122f1e817470#file-update-v-parallel-txt) for an example.) This PR addresses this in its 2nd commit by switching to serial fetching in debug/verbose mode, assuming that a clear output is more important than performance. (See [update-v-serialized.txt](https://gist.github.com/UniqMartin/e63898f3122f1e817470#file-update-v-serialized-txt) for the improved output.)

The 3rd commit improves on that (and in a way addresses #49893) by adding a header before every fetch and update (merge or rebase) operation as well as before handing over to `brew update-report`. (Of course only in verbose mode. See [update-v-with-headers.diff](https://gist.github.com/UniqMartin/e63898f3122f1e817470#file-update-v-with-headers-diff) for a diff that highlights the added headers.)

The 1st commit provides previously not available shell implementations of `ohai`, `oh1`, etc. the above changes depend on. (I thoroughly tested things locally, but the changes are actually fairly non-intrusive.)