### PR TITLE
gnu-time: patch to fix "Maximum resident set size" is too big.

### DIFF
--- a/Library/Formula/gnu-time.rb
+++ b/Library/Formula/gnu-time.rb
@@ -41,9 +41,18 @@ end
 
 __END__
 diff --git a/time.c b/time.c
-index 9d5cf2c..97611f5 100644
+index 9d5cf2c..7b6e011 100644
 --- a/time.c
 +++ b/time.c
+@@ -392,7 +392,7 @@ summarize (fp, fmt, command, resp)
+ 		       ptok ((UL) resp->ru.ru_ixrss) / MSEC_TO_TICKS (v));
+ 	      break;
+ 	    case 'M':		/* Maximum resident set size.  */
+-	      fprintf (fp, "%lu", ptok ((UL) resp->ru.ru_maxrss));
++	      fprintf (fp, "%lu", (UL) resp->ru.ru_maxrss / 1024);
+ 	      break;
+ 	    case 'O':		/* Outputs.  */
+ 	      fprintf (fp, "%ld", resp->ru.ru_oublock);
 @@ -628,7 +628,7 @@ run_command (cmd, resp)
    signal (SIGQUIT, quit_signal);
  }


### PR DESCRIPTION
Description of problem:
GNU time can print out the maximum RSS usage of its subprocess.
The ru_maxrss value returned by the getrusage syscall is in units of bytes, but GNU time incorrectly treats this as a number of pages, multiplying the value by 4k before displaying it.

How reproducible: Always

Steps to Reproduce:
1. gtime -f %M perl -e '"x" x 400 x 1024 x 1024'

Actual results: A bit over 1600000000.

Expected results: Approximately 400000, since Perl should only be allocating around 400 MB

Additional info:
According to the getrusage(2) manpage (OS X 10.11.3):
  ru_maxrss the maximum resident set size utilized (in bytes).