### PR TITLE
brew pull: verify bottles using platform-independent download

### DIFF
--- a/Library/Homebrew/bottles.rb
+++ b/Library/Homebrew/bottles.rb
@@ -72,6 +72,19 @@ class Bintray
       "bottles-#{tap.repo}"
     end
   end
+
+  # Publishes the bottle files for a given formula to Bintray
+  def self.publish_bottle_files(f, tap, creds)
+    repo = Bintray.repository(tap)
+    package = Bintray.package(f.name)
+    version = f.pkg_version
+    curl "-w", '\n', "--silent", "--fail",
+         "-u#{creds[:user]}:#{creds[:key]}", "-X", "POST",
+         "-H", "Content-Type: application/json",
+         "-d", '{"publish_wait_for_secs": 0}',
+         "https://api.bintray.com/content/homebrew/#{repo}/#{package}/#{version}/publish"
+  end
+
 end
 
 class BottleCollector

--- a/Library/Homebrew/cmd/_internal.rb
+++ b/Library/Homebrew/cmd/_internal.rb
@@ -1,0 +1,25 @@
+# A private interface for `brew` to run its own internal APIs in a separate `brew` command
+#
+# This is not intended for use as an end-user command or public API. Any of its behavior
+# is subject to change at any time.
+
+module Homebrew
+  def _internal
+    if ARGV.named.empty?
+      odie "This command requires at least one argument naming a subcommand"
+    end
+    subcommand_name = ARGV.named.first
+    other_args = ARGV.named[1..-1]
+
+    case subcommand_name
+      when "verify-bintray-publish"
+        require "cmd/pull"
+        verify_bintray_publish(other_args)
+      when "fetch-bottle-any-arch"
+        require "cmd/fetch"
+        fetch_bottle_any_arch(other_args)
+      else
+        odie "Invalid _internal subcommand: #{subcommand_name}"
+    end
+  end
+end

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -41,6 +41,18 @@ module Homebrew
     end
   end
 
+  # For Homebrew's internal use.
+  # Fetches a bottle for any arch, without falling back to source download.
+  def fetch_bottle_any_arch(names)
+    names.each do |fname|
+      f = Formula[fname]
+      f.print_tap_action :verb => "Fetching"
+      bottle_tag = f.stable.bottle_specification.collector.keys.first
+      bottle = f.bottle_for_platform(bottle_tag)
+      fetch_formula(bottle)
+    end
+  end
+
   def fetch_bottle?(f)
     return true if ARGV.force_bottle? && f.bottle
     return false unless f.bottle && f.pour_bottle?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -267,6 +267,12 @@ class Formula
     Bottle.new(self, bottle_specification) if bottled?
   end
 
+  # A Bottle object for the active {SoftwareSpec}, for a given platform tag.
+  # @private
+  def bottle_for_platform(tag)
+    Bottle.new(self, bottle_specification, tag)
+  end
+
   # The description of the software.
   # @see .desc
   def desc

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -219,6 +219,7 @@ class Bottle
       @version = version
       @tag = tag
       @revision = revision
+      #puts "initialize Bottle.Filename: #{name} #{version} #{tag} #{revision}"
     end
 
     def to_s
@@ -243,13 +244,14 @@ class Bottle
   def_delegators :resource, :url, :fetch, :verify_download_integrity
   def_delegators :resource, :cached_download, :clear_cache
 
-  def initialize(formula, spec)
+  def initialize(formula, spec, tag = bottle_tag)
     @name = formula.name
     @resource = Resource.new
     @resource.owner = formula
     @spec = spec
+    @tag = tag
 
-    checksum, tag = spec.checksum_for(bottle_tag)
+    checksum, tag = spec.checksum_for(tag)
 
     filename = Filename.create(formula, tag, spec.revision)
     @resource.url(build_url(spec.root_url, filename))


### PR DESCRIPTION
Revises `brew pull --bottle` logic to be platform-independent, have more concise output, and reduce waiting time for bottle downloads.

Fixes #48731

### Platform-independent bottle verification

Fixes bottle verification on systems who don't have a bottle built for that OS version. Previously, the `brew fetch` it was doing to wait on and test the bottle file would fall back and download the source code instead, which isn't what we want here.

This chang switches to selecting bottle files that are known to exist. It now polls for the presence of updated bottles on Bintray using HTTP HEAD requests. This avoids the spurious "Error" messages that happen in the normal course of  a `brew pull --bottle` and makes output more concise.

Switches to a constant delay in polling now that output is terser. Exponential backoff is useful for relieving congestion, but that isn't important here, since there's so little `brew pull` traffic. (It's a manual tool used by less than a couple dozen people.) Using a constant retry delay reduces the waiting time wasted when using longer retry periods that the file might become available in the middle of.

Then it uses a `fetch` variant to pick, download, and checksum one of the known-extant bottle files. (Without requiring it to be for the current machine's platform.

Adds --force to the fetch to make sure it actually verifies the existence on the server instead of relying on the local cache.

Adds a `Formula.bottle_for_platform?` method and an optional argument to `Bottle`'s initializer to allow creating of Bottle objects for other platforms so the code can work with them.

###  `brew _internal` mechanism

This introduces a new `brew _internal` subcommand as a mechanism for `brew` to be able to call its own internals through a separate `brew` command. The `_internal` command is for `brew`'s own use, and subject to behavior change at any time. This lets `brew` call itself without committing to adding things to the public interface of the command.

Running stuff in separate, fresh `brew` commands is necessary for `brew pull` because the pull actions can change the class definitions for formulae and `brew` itself. That's why the existing "current_versions_from_info_external" is there. In this case, the bottle revisions in in-process Formula objects may be wrong once bottle-modifying patches are applied, so the bottle URL resolution needs to be done in a fresh `brew` command. The old code relied on a separate `brew fetch` to do this, but that only works if you want the bottle for the current system's platform, and don't mind falling back to downloading the source.

## Visible behavior changes

The old `brew pull --bottle` would look like this, with red "Error" messages even during the normal course of events.

<img width="762" alt="brew pull --bottle - old behavior" src="https://cloud.githubusercontent.com/assets/2618447/13728278/842a3658-e8e8-11e5-84ad-663bdaa7cd9e.png">

With this PR, it now looks like this. The polling retries are displayed as dots after "Waiting for files to appear...". It also includes the formula name/version/revision in the "publishing to bintray" status message.

<img width="832" alt="screen shot 2016-03-13 at 5 18 19 am" src="https://cloud.githubusercontent.com/assets/2618447/13728281/9282fb72-e8e8-11e5-8670-9a7933b50a37.png">

## Procedural stuff

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [X] Have you successfully ran `brew tests` with your changes locally?

No automated tests for this change. It interacts with Bintray and GitHub PRs, so it's hard to isolate. I did break the bintray verification code out in to a separate function so it's possible to call it directly without going through the rest of `brew pull`.