### PR TITLE
macvim: stop setting SDK and developer dir

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -89,14 +89,6 @@ class Macvim < Formula
       args << "--enable-pythoninterp"
     end
 
-    # configure appends "SDKS/..." to the value of `xcode-select -print-path`,
-    # but this isn't correct on recent Xcode, so we need to set it manually.
-    # This is a bug, and it should be fixed upstream.
-    unless MacOS::CLT.installed?
-      args << "--with-developer-dir=#{MacOS::Xcode.prefix}/Platforms/MacOSX.platform/Developer"
-      args << "--with-macsdk=#{MacOS.version}"
-    end
-
     system "./configure", *args
     system "make"
 


### PR DESCRIPTION
macvim: stop setting SDK and developer dir

As of Xcode 7.0 (7A220), a single SDK named after the latest version of
OS X is distributed, so it is incorrect to explicitly set a lower SDK
since it just won't exist. Instead, you're supposed to rely on
MACOSX_DEPLOYMENT_TARGET, which MacVim's configure already sets
correctly unless we intervene and make it incorrect:

  https://github.com/macvim-dev/macvim/commit/55323a513dd928b531941573176ce35c5455c05f
  https://github.com/macvim-dev/macvim/pull/104
  https://github.com/macvim-dev/macvim/issues/98

Explicit setting of the SDK was originally added in

  https://github.com/Homebrew/homebrew/commit/0b50110107ea2998e65011ec31ce45931b446dab

This no longer appears to be necessary. If someone finds that it still
is for some reason, the code removed by this commit can be restored with
a check for Xcode < 7 added instead.

Closes #50180

