### PR TITLE
Gnome 3.20

### DIFF
--- a/Library/Formula/anjuta.rb
+++ b/Library/Formula/anjuta.rb
@@ -1,8 +1,8 @@
 class Anjuta < Formula
   desc "GNOME Integrated Development Environment"
   homepage "http://anjuta.org"
-  url "https://download.gnome.org/sources/anjuta/3.18/anjuta-3.18.2.tar.xz"
-  sha256 "be864f2f1807e1b870697f646294e997d221d5984a135245543b719e501cef8e"
+  url "https://download.gnome.org/sources/anjuta/3.20/anjuta-3.20.0.tar.xz"
+  sha256 "a676c587a28f784ec2096775460cd29fafc3f0216c53e0821641bcd9126b6935"
 
   bottle do
     revision 1

--- a/Library/Formula/at-spi2-atk.rb
+++ b/Library/Formula/at-spi2-atk.rb
@@ -1,8 +1,8 @@
 class AtSpi2Atk < Formula
   desc "Accessibility Toolkit GTK+ module"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-atk/2.20/at-spi2-atk-2.20.0.tar.xz"
-  sha256 "a24b142b6e8f1dd2d57a657447dde3e0ae29df481968c88673a58d4ce44f3ad2"
+  url "https://download.gnome.org/sources/at-spi2-atk/2.20/at-spi2-atk-2.20.1.tar.xz"
+  sha256 "2358a794e918e8f47ce0c7370eee8fc8a6207ff1afe976ec9ff547a03277bf8e"
 
   bottle do
     cellar :any

--- a/Library/Formula/at-spi2-atk.rb
+++ b/Library/Formula/at-spi2-atk.rb
@@ -1,8 +1,8 @@
 class AtSpi2Atk < Formula
   desc "Accessibility Toolkit GTK+ module"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-atk/2.18/at-spi2-atk-2.18.1.tar.xz"
-  sha256 "c4b15f9386d34d464ddad5f6cc85669742c016df87141ceee93513245979c12d"
+  url "https://download.gnome.org/sources/at-spi2-atk/2.20/at-spi2-atk-2.20.0.tar.xz"
+  sha256 "a24b142b6e8f1dd2d57a657447dde3e0ae29df481968c88673a58d4ce44f3ad2"
 
   bottle do
     cellar :any

--- a/Library/Formula/at-spi2-core.rb
+++ b/Library/Formula/at-spi2-core.rb
@@ -1,8 +1,8 @@
 class AtSpi2Core < Formula
   desc "Protocol definitions and daemon for D-Bus at-spi"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-core/2.18/at-spi2-core-2.18.3.tar.xz"
-  sha256 "ada26add94155f97d0f601a20cb7a0e3fd3ba1588c3520b7288316494027d629"
+  url "https://download.gnome.org/sources/at-spi2-core/2.20/at-spi2-core-2.20.0.tar.xz"
+  sha256 "dcc49fb7c08e582910b21ff1e4110b22ab66068a4c6f0db52b098d66794c609b"
 
   bottle do
     sha256 "96b67926248f6950a20ea28fde034e9a91b6c4c4a14eb3cd54e0aead53224ce6" => :el_capitan

--- a/Library/Formula/at-spi2-core.rb
+++ b/Library/Formula/at-spi2-core.rb
@@ -1,8 +1,8 @@
 class AtSpi2Core < Formula
   desc "Protocol definitions and daemon for D-Bus at-spi"
   homepage "http://a11y.org"
-  url "https://download.gnome.org/sources/at-spi2-core/2.20/at-spi2-core-2.20.0.tar.xz"
-  sha256 "dcc49fb7c08e582910b21ff1e4110b22ab66068a4c6f0db52b098d66794c609b"
+  url "https://download.gnome.org/sources/at-spi2-core/2.20/at-spi2-core-2.20.1.tar.xz"
+  sha256 "6ed858e781f5aa9a9662b3beb5ef82f733dac040afc8255d85dffd2097f16900"
 
   bottle do
     sha256 "96b67926248f6950a20ea28fde034e9a91b6c4c4a14eb3cd54e0aead53224ce6" => :el_capitan

--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -1,9 +1,8 @@
 class Atk < Formula
   desc "GNOME accessibility toolkit"
   homepage "https://library.gnome.org/devel/atk/"
-  url "https://download.gnome.org/sources/atk/2.18/atk-2.18.0.tar.xz"
-  sha256 "ce6c48d77bf951083029d5a396dd552d836fff3c1715d3a7022e917e46d0c92b"
-  revision 1
+  url "https://download.gnome.org/sources/atk/2.20/atk-2.20.0.tar.xz"
+  sha256 "493a50f6c4a025f588d380a551ec277e070b28a82e63ef8e3c06b3ee7c1238f0"
 
   bottle do
     sha256 "fe1c92ea4289e68e062a861b7b150ccf69beba70e95d38f7f028b52ca2f6314d" => :el_capitan

--- a/Library/Formula/baobab.rb
+++ b/Library/Formula/baobab.rb
@@ -1,8 +1,8 @@
 class Baobab < Formula
   desc "Gnome disk usage analyzer"
   homepage "https://wiki.gnome.org/Apps/Baobab"
-  url "https://download.gnome.org/sources/baobab/3.20/baobab-3.20.0.tar.xz"
-  sha256 "5cdd65b287079cdfafe92b6170fc7bebae5309d4e19adafcd64dc4837e627d07"
+  url "https://download.gnome.org/sources/baobab/3.20/baobab-3.20.1.tar.xz"
+  sha256 "e9dff12a76b0d730ce224215860512eb0188280c622faf186937563b96249d1f"
 
   bottle do
     sha256 "55ea4703861707e433de02cf3d18420ffa0de197c089a8a28c4ee5c43917eb88" => :el_capitan

--- a/Library/Formula/baobab.rb
+++ b/Library/Formula/baobab.rb
@@ -1,8 +1,8 @@
 class Baobab < Formula
   desc "Gnome disk usage analyzer"
   homepage "https://wiki.gnome.org/Apps/Baobab"
-  url "https://download.gnome.org/sources/baobab/3.18/baobab-3.18.1.tar.xz"
-  sha256 "c2ac90426390e77147446a290c1480c49936c0a224f740b555ddaec2675b44b5"
+  url "https://download.gnome.org/sources/baobab/3.20/baobab-3.20.0.tar.xz"
+  sha256 "5cdd65b287079cdfafe92b6170fc7bebae5309d4e19adafcd64dc4837e627d07"
 
   bottle do
     sha256 "55ea4703861707e433de02cf3d18420ffa0de197c089a8a28c4ee5c43917eb88" => :el_capitan

--- a/Library/Formula/clutter-gst.rb
+++ b/Library/Formula/clutter-gst.rb
@@ -1,8 +1,8 @@
 class ClutterGst < Formula
   desc "ClutterMedia interface using GStreamer for video and audio"
   homepage "https://developer.gnome.org/clutter-gst/"
-  url "https://download.gnome.org/sources/clutter-gst/3.0/clutter-gst-3.0.16.tar.xz"
-  sha256 "803e8b7265e63e0581e21fd0c6064792dfe951512e9f515e9e7a9b452caaf9f0"
+  url "https://download.gnome.org/sources/clutter-gst/3.0/clutter-gst-3.0.18.tar.xz"
+  sha256 "0aec0d0c6020cd19a5bb0dab1165a92748f81a9a3acdfabb0f966d5f53bc8093"
 
   bottle do
     sha256 "713a99de8f38abe30e09c31259c678e461464b6b1d525373d21405a5028ef830" => :el_capitan

--- a/Library/Formula/clutter-gtk.rb
+++ b/Library/Formula/clutter-gtk.rb
@@ -1,8 +1,8 @@
 class ClutterGtk < Formula
   desc "GTK+ integration library for Clutter"
   homepage "https://wiki.gnome.org/Projects/Clutter"
-  url "https://download.gnome.org/sources/clutter-gtk/1.6/clutter-gtk-1.6.6.tar.xz"
-  sha256 "9440a68600f58d00fe0af35383738943e8ead9907f4cf507a102d96822434a28"
+  url "https://download.gnome.org/sources/clutter-gtk/1.8/clutter-gtk-1.8.0.tar.xz"
+  sha256 "742ef9d68ece36cbb1b2e1a4a6fbdad932f6645360be7e6de75abbb140dfbf1d"
 
   bottle do
     sha256 "b877f157f95367d57649090765d3ee751bc0640f3d22fe7c4b548036559f70f2" => :el_capitan

--- a/Library/Formula/clutter.rb
+++ b/Library/Formula/clutter.rb
@@ -1,8 +1,8 @@
 class Clutter < Formula
   desc "Generic high-level canvas library"
   homepage "https://wiki.gnome.org/Projects/Clutter"
-  url "https://download.gnome.org/sources/clutter/1.24/clutter-1.24.2.tar.xz"
-  sha256 "9631c98cb4bcbfec15e1bbe9eaa6eef0f127201552fce40d7d28f2133803cd63"
+  url "https://download.gnome.org/sources/clutter/1.26/clutter-1.26.0.tar.xz"
+  sha256 "67514e7824b3feb4723164084b36d6ce1ae41cb3a9897e9f1a56c8334993ce06"
 
   bottle do
     sha256 "6b5dfa3423c12b165975b543b3d248c6a2d952a11f54592adb521d545762fb2e" => :el_capitan

--- a/Library/Formula/devhelp.rb
+++ b/Library/Formula/devhelp.rb
@@ -1,8 +1,8 @@
 class Devhelp < Formula
   desc "API documentation browser for GTK+ and GNOME"
   homepage "https://wiki.gnome.org/Apps/Devhelp"
-  url "https://download.gnome.org/sources/devhelp/3.18/devhelp-3.18.1.tar.xz"
-  sha256 "303a162ad294dc6f9984898e501a06dc5d2aa9812b06801c2e39b250d8c51aef"
+  url "https://download.gnome.org/sources/devhelp/3.20/devhelp-3.20.0.tar.xz"
+  sha256 "a23375c2e2b2ef6240994bc2327fcacfd42403af6d872d0cba2e16dd45ca1f1d"
 
   bottle do
     sha256 "0a8fceef8356c847134a86553a469af6c4e48f72b9e8e9b6576e4bcfe80eca79" => :el_capitan

--- a/Library/Formula/evince.rb
+++ b/Library/Formula/evince.rb
@@ -1,9 +1,8 @@
 class Evince < Formula
   desc "GNOME document viewer"
   homepage "https://wiki.gnome.org/Apps/Evince"
-  url "https://download.gnome.org/sources/evince/3.18/evince-3.18.2.tar.xz"
-  sha256 "42ad6c7354d881a9ecab136ea84ff867acb942605bcfac48b6c12e1c2d8ecb17"
-  revision 3
+  url "https://download.gnome.org/sources/evince/3.20/evince-3.20.0.tar.xz"
+  sha256 "cf8358a453686c2a7f85d245f83fe918c0ce02eb6532339f3e02e31249a5a280"
 
   bottle do
     sha256 "1285a7fdb434b1954a82b626af26541e6de62da829701c9c8804f033dc449ed3" => :el_capitan
@@ -25,10 +24,6 @@ class Evince < Formula
   depends_on "shared-mime-info"
   depends_on "djvulibre"
   depends_on :python if MacOS.version <= :snow_leopard
-
-  # adds support for UTF-8 filenames in the DjVu backend
-  # submitted upstream as https://bugzilla.gnome.org/show_bug.cgi?id=761161
-  patch :DATA
 
   def install
     # forces use of gtk3-update-icon-cache instead of gtk-update-icon-cache. No bugreport should
@@ -58,23 +53,3 @@ class Evince < Formula
     assert_match /#{version}/, shell_output("#{bin}/evince --version")
   end
 end
-
-__END__
-diff --git a/backend/djvu/djvu-document.c b/backend/djvu/djvu-document.c
-index 06ce813..6711f31 100644
---- a/backend/djvu/djvu-document.c
-+++ b/backend/djvu/djvu-document.c
-@@ -164,8 +164,12 @@ djvu_document_load (EvDocument  *document,
-	filename = g_filename_from_uri (uri, NULL, error);
-	if (!filename)
-		return FALSE;
--
-+
-+#ifdef __APPLE__
-+	doc = ddjvu_document_create_by_filename_utf8 (djvu_document->d_context, filename, TRUE);
-+#else
-	doc = ddjvu_document_create_by_filename (djvu_document->d_context, filename, TRUE);
-+#endif
-
-	if (!doc) {
-		g_free (filename);

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -1,8 +1,8 @@
 class GdkPixbuf < Formula
   desc "Toolkit for image loading and pixel buffer manipulation"
   homepage "http://gtk.org"
-  url "https://download.gnome.org/sources/gdk-pixbuf/2.32/gdk-pixbuf-2.32.3.tar.xz"
-  sha256 "2b6771f1ac72f687a8971e59810b8dc658e65e7d3086bd2e676e618fd541d031"
+  url "https://download.gnome.org/sources/gdk-pixbuf/2.34/gdk-pixbuf-2.34.0.tar.xz"
+  sha256 "d55e5b383ee219bd0e23bf6ed4427d56a7db5379729a6e3e0a0e0eba9a8d8879"
 
   bottle do
     revision 1
@@ -34,7 +34,7 @@ class GdkPixbuf < Formula
             "--enable-introspection=yes",
             "--disable-Bsymbolic",
             "--enable-static",
-            "--without-gdiplus",]
+            "--without-gdiplus"]
 
     args << "--enable-relocations" if build.with?("relocations")
 

--- a/Library/Formula/gdl.rb
+++ b/Library/Formula/gdl.rb
@@ -1,8 +1,8 @@
 class Gdl < Formula
   desc "GNOME Docking Library provides docking features for GTK+ 3"
   homepage "https://developer.gnome.org/gdl/"
-  url "https://download.gnome.org/sources/gdl/3.18/gdl-3.18.0.tar.xz"
-  sha256 "1499884e4fce375a963cf2b98b90e6724144f9b1f1ac8b84d765f4c85a2140b2"
+  url "https://download.gnome.org/sources/gdl/3.20/gdl-3.20.0.tar.xz"
+  sha256 "53d3a3bb9b9be25b3a40c644fdbbb57a5a63ee1f5f839c2266d1cd9779360e8b"
 
   bottle do
     sha256 "2510a3cf303aad9f105ee5615e2d23cbbb2c43e73f53bdbeffd815f9818dbcb5" => :el_capitan

--- a/Library/Formula/gedit.rb
+++ b/Library/Formula/gedit.rb
@@ -1,8 +1,8 @@
 class Gedit < Formula
   desc "The GNOME text editor"
   homepage "https://wiki.gnome.org/Apps/Gedit"
-  url "https://download.gnome.org/sources/gedit/3.20/gedit-3.20.0.tar.xz"
-  sha256 "4013dedd2b58ce215ed40b028a1223df5b5fc44571388c008f31f77379a77bb2"
+  url "https://download.gnome.org/sources/gedit/3.20/gedit-3.20.1.tar.xz"
+  sha256 "9a47e3073f844b67d7358f5a43c71ab04b442b70fcd3c629da77879e9a0c1dc4"
 
   bottle do
     sha256 "12119b98084b680cb7db10db4b7a60bffb60ff2ba14dd2b6c4f2af8a95df1630" => :el_capitan
@@ -14,13 +14,13 @@ class Gedit < Formula
   depends_on "intltool" => :build
   depends_on "itstool" => :build
   depends_on "gtk+3"
-  depends_on "gspell"
   depends_on "gtk-mac-integration"
   depends_on "gobject-introspection"
   depends_on "enchant"
   depends_on "iso-codes"
   depends_on "libxml2"
   depends_on "libpeas"
+  depends_on "gspell"
   depends_on "gtksourceview3"
   depends_on "gsettings-desktop-schemas"
   depends_on "gnome-icon-theme"

--- a/Library/Formula/gedit.rb
+++ b/Library/Formula/gedit.rb
@@ -1,8 +1,8 @@
 class Gedit < Formula
   desc "The GNOME text editor"
   homepage "https://wiki.gnome.org/Apps/Gedit"
-  url "https://download.gnome.org/sources/gedit/3.18/gedit-3.18.3.tar.xz"
-  sha256 "6762ac0d793b0f754a2da5f88739d04fa39daa7491c5c46401d24bcef76c32e7"
+  url "https://download.gnome.org/sources/gedit/3.20/gedit-3.20.0.tar.xz"
+  sha256 "4013dedd2b58ce215ed40b028a1223df5b5fc44571388c008f31f77379a77bb2"
 
   bottle do
     sha256 "12119b98084b680cb7db10db4b7a60bffb60ff2ba14dd2b6c4f2af8a95df1630" => :el_capitan
@@ -14,6 +14,7 @@ class Gedit < Formula
   depends_on "intltool" => :build
   depends_on "itstool" => :build
   depends_on "gtk+3"
+  depends_on "gspell"
   depends_on "gtk-mac-integration"
   depends_on "gobject-introspection"
   depends_on "enchant"

--- a/Library/Formula/geocode-glib.rb
+++ b/Library/Formula/geocode-glib.rb
@@ -1,8 +1,8 @@
 class GeocodeGlib < Formula
   desc "GNOME library for gecoding and reverse geocoding"
   homepage "https://developer.gnome.org/geocode-glib"
-  url "https://download.gnome.org/sources/geocode-glib/3.20/geocode-glib-3.20.0.tar.xz"
-  sha256 "5f2264238e9481a95ca260ba2c652bebd247ec1852a27ded5b126117eb1bb6ba"
+  url "https://download.gnome.org/sources/geocode-glib/3.20/geocode-glib-3.20.1.tar.xz"
+  sha256 "669fc832cabf8cc2f0fc4194a8fa464cdb9c03ebf9aca5353d7cf935ba8637a2"
 
   bottle do
     sha256 "dad6f3fbbb15e9964b4d754ce82de4466c3f3079f8d1686b96230c01fb2e914b" => :el_capitan

--- a/Library/Formula/geocode-glib.rb
+++ b/Library/Formula/geocode-glib.rb
@@ -1,8 +1,8 @@
 class GeocodeGlib < Formula
   desc "GNOME library for gecoding and reverse geocoding"
   homepage "https://developer.gnome.org/geocode-glib"
-  url "https://download.gnome.org/sources/geocode-glib/3.18/geocode-glib-3.18.2.tar.xz"
-  sha256 "95b11ef2697ac5dbb2f397e7117e08e157b2168624c71507656928095012494e"
+  url "https://download.gnome.org/sources/geocode-glib/3.20/geocode-glib-3.20.0.tar.xz"
+  sha256 "5f2264238e9481a95ca260ba2c652bebd247ec1852a27ded5b126117eb1bb6ba"
 
   bottle do
     sha256 "dad6f3fbbb15e9964b4d754ce82de4466c3f3079f8d1686b96230c01fb2e914b" => :el_capitan

--- a/Library/Formula/gitg.rb
+++ b/Library/Formula/gitg.rb
@@ -1,8 +1,8 @@
 class Gitg < Formula
   desc "GNOME GUI client to view git repositories"
   homepage "https://wiki.gnome.org/Apps/Gitg"
-  url "https://download.gnome.org/sources/gitg/3.18/gitg-3.18.0.tar.xz"
-  sha256 "fa4b7b9c492f13f5f1d864af1281ea377ac8c7619c856e05f533b18989edf421"
+  url "https://download.gnome.org/sources/gitg/3.20/gitg-3.20.0.tar.xz"
+  sha256 "1f09f61208349d003f228e51dc9709bd3426960f5585c0e38197bd02b51f3346"
 
   bottle do
     sha256 "5da83eb431d2bac44657f9be88a3e227d112754bd520215a7d590a62a243f08d" => :el_capitan

--- a/Library/Formula/glade3.rb
+++ b/Library/Formula/glade3.rb
@@ -1,0 +1,59 @@
+class Glade3 < Formula
+  desc "RAD tool for the GTK+ and GNOME environment"
+  homepage "https://glade.gnome.org/"
+  url "https://download.gnome.org/sources/glade/3.20/glade-3.20.0.tar.xz"
+  sha256 "82d96dca5dec40ee34e2f41d49c13b4ea50da8f32a3a49ca2da802ff14dc18fe"
+
+  depends_on "pkg-config" => :build
+  depends_on "intltool" => :build
+  depends_on "itstool" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "gnome-common" => :build
+  depends_on "yelp-tools" => :build
+  depends_on "gettext"
+  depends_on "libxml2" => "with-python"
+  depends_on "hicolor-icon-theme"
+  depends_on "gtk+3"
+  depends_on "gtk-mac-integration"
+  depends_on "pygobject3"
+
+  patch :DATA
+
+  def install
+    # Find our docbook catalog
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+    ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python2.7/site-packages"
+
+    system "autoreconf"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--enable-introspection=no",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    # executable test (GUI)
+    system "#{bin}/glade-3", "--version"
+  end
+end
+
+__END__
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 4b37f94..fbfe7b4 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -10,7 +10,8 @@ glade_CPPFLAGS = \
+ 	$(GTK_CFLAGS)      \
+ 	$(GTK_MAC_CFLAGS)  \
+ 	$(WARN_CFLAGS)     \
+-	$(AM_CPPFLAGS)
++	$(AM_CPPFLAGS)     \
++	-xobjective-c
+ 
+ glade_CFLAGS =           \
+ 	$(GMODULE_EXPORT_CFLAGS) \
+

--- a/Library/Formula/glib-networking.rb
+++ b/Library/Formula/glib-networking.rb
@@ -1,9 +1,8 @@
 class GlibNetworking < Formula
   desc "Network related modules for glib"
   homepage "https://launchpad.net/glib-networking"
-  url "https://download.gnome.org/sources/glib-networking/2.46/glib-networking-2.46.1.tar.xz"
-  sha256 "d5034214217f705891b6c9e719cc2c583c870bfcfdc454ebbb5e5e8940ac90b1"
-  revision 1
+  url "https://download.gnome.org/sources/glib-networking/2.48/glib-networking-2.48.0.tar.xz"
+  sha256 "7a1f3312e757b97af94e2db8a1f14eb9cc018c983931ecdf3b0c54acece39024"
 
   bottle do
     cellar :any
@@ -62,7 +61,7 @@ class GlibNetworking < Formula
       "-I#{HOMEBREW_PREFIX}/opt/gettext/include",
       "-L#{HOMEBREW_PREFIX}/lib",
       "-L#{HOMEBREW_PREFIX}/opt/gettext/lib",
-      "-lgio-2.0", "-lgobject-2.0", "-lglib-2.0", "-lintl",
+      "-lgio-2.0", "-lgobject-2.0", "-lglib-2.0", "-lintl"
     ]
 
     system ENV.cc, "gtls-test.c", "-o", "gtls-test", *flags

--- a/Library/Formula/glib.rb
+++ b/Library/Formula/glib.rb
@@ -1,8 +1,8 @@
 class Glib < Formula
   desc "Core application library for C"
   homepage "https://developer.gnome.org/glib/"
-  url "https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz"
-  sha256 "5031722e37036719c1a09163cc6cf7c326e4c4f1f1e074b433c156862bd733db"
+  url "https://download.gnome.org/sources/glib/2.48/glib-2.48.0.tar.xz"
+  sha256 "744be6931ca914c68af98dc38ff6b0cf8381d65e335060faddfbf04c17147c34"
 
   bottle do
     sha256 "7712b8d7682c79d31f8325e4a6a99d43ed480907420193035ba4a874603d720e" => :el_capitan
@@ -18,6 +18,7 @@ class Glib < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "libffi"
+  depends_on "pcre"
 
   fails_with :llvm do
     build 2334

--- a/Library/Formula/glibmm.rb
+++ b/Library/Formula/glibmm.rb
@@ -1,8 +1,8 @@
 class Glibmm < Formula
   desc "C++ interface to glib"
   homepage "http://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/glibmm/2.46/glibmm-2.46.3.tar.xz"
-  sha256 "c78654addeb27a1213bedd7cd21904a45bbb98a5ba2f2f0de2b2f1a5682d86cf"
+  url "https://download.gnome.org/sources/glibmm/2.48/glibmm-2.48.1.tar.xz"
+  sha256 "dc225f7d2f466479766332483ea78f82dc349d59399d30c00de50e5073157cdf"
 
   bottle do
     cellar :any

--- a/Library/Formula/gnome-builder.rb
+++ b/Library/Formula/gnome-builder.rb
@@ -1,9 +1,8 @@
 class GnomeBuilder < Formula
   desc "IDE for GNOME"
   homepage "https://wiki.gnome.org/Apps/Builder"
-  url "https://download.gnome.org/sources/gnome-builder/3.18/gnome-builder-3.18.1.tar.xz"
-  mirror "https://launchpad.net/ubuntu/+archive/primary/+files/gnome-builder_3.18.1.orig.tar.xz"
-  sha256 "501c95220dcf8ca44a5748e863492377fe2c3aee78a95973d6819b1836e5407c"
+  url "https://download.gnome.org/sources/gnome-builder/3.20/gnome-builder-3.20.0.tar.xz"
+  sha256 "1260f38d6fa0008c1b10238873b764b3fb47c383267bad083b298a7bcae8fb9b"
 
   bottle do
     sha256 "f7d422a29b7c9b98c20bdce9e8a56b14265fad5d9ce174d77c686adb26d752ad" => :el_capitan
@@ -13,6 +12,7 @@ class GnomeBuilder < Formula
 
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
+  depends_on "itstool" => :build
   depends_on "libgit2-glib"
   depends_on "gtk+3"
   depends_on "libpeas"
@@ -31,13 +31,6 @@ class GnomeBuilder < Formula
 
   def install
     ENV.cxx11
-
-    # Fix build failure on case-sensitive volumes for libgit2-glib without vala.
-    # Reported 7th Mar 2016 to https://bugzilla.gnome.org/show_bug.cgi?id=763208
-    unless File.exist?(Formula["libgit2-glib"].share/"vala/vapi/ggit-1.0.vapi")
-      inreplace Dir["libide/{Makefile.am,Makefile.in,libide-1.0.deps}"],
-        "ggit-1.0", "Ggit-1.0"
-    end
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Library/Formula/gnome-icon-theme.rb
+++ b/Library/Formula/gnome-icon-theme.rb
@@ -1,8 +1,8 @@
 class GnomeIconTheme < Formula
   desc "Icons for the GNOME project"
   homepage "https://developer.gnome.org"
-  url "https://download.gnome.org/sources/adwaita-icon-theme/3.18/adwaita-icon-theme-3.18.0.tar.xz"
-  sha256 "5e9ce726001fdd8ee93c394fdc3cdb9e1603bbed5b7c62df453ccf521ec50e58"
+  url "https://download.gnome.org/sources/adwaita-icon-theme/3.20/adwaita-icon-theme-3.20.tar.xz"
+  sha256 "7a0a887349f340dd644032f89d81264b694c4b006bd51af1c2c368d431e7ae35"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/gnome-themes-standard.rb
+++ b/Library/Formula/gnome-themes-standard.rb
@@ -1,8 +1,8 @@
 class GnomeThemesStandard < Formula
   desc "Default themes for the GNOME desktop environment"
   homepage "https://git.gnome.org/browse/gnome-themes-standard/"
-  url "https://download.gnome.org/sources/gnome-themes-standard/3.18/gnome-themes-standard-3.18.0.tar.xz"
-  sha256 "e646eb04c225282b7df7fff65741adaad4cf9ed2c12616b7310e7edd27d2bacb"
+  url "https://download.gnome.org/sources/gnome-themes-standard/3.20/gnome-themes-standard-3.20.tar.xz"
+  sha256 "1cde84b34da310e6f2d403bfdbe9abb0798e5f07a1d1b4fde82af8e97edd3bdc"
 
   bottle do
     cellar :any

--- a/Library/Formula/gnumeric.rb
+++ b/Library/Formula/gnumeric.rb
@@ -1,8 +1,8 @@
 class Gnumeric < Formula
   desc "GNOME Spreadsheet Application"
   homepage "https://projects.gnome.org/gnumeric/"
-  url "https://download.gnome.org/sources/gnumeric/1.12/gnumeric-1.12.27.tar.xz"
-  sha256 "383a5b6eca17f0a5a0b552edcc10320fa719d10c69c7b6fb29d5a11808f1d1c9"
+  url "https://download.gnome.org/sources/gnumeric/1.12/gnumeric-1.12.28.tar.xz"
+  sha256 "02d4ad13389e51f24638a0a59dbfb870ec8120efc453b2dca8804167f2b94dbb"
 
   bottle do
     sha256 "ef111a401feca256bbd20ac542d09024432abf7f5717f55f1251a4de071e3820" => :el_capitan

--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -1,9 +1,8 @@
 class GobjectIntrospection < Formula
   desc "Generate introspection data for GObject libraries"
   homepage "https://live.gnome.org/GObjectIntrospection"
-  url "https://download.gnome.org/sources/gobject-introspection/1.46/gobject-introspection-1.46.0.tar.xz"
-  sha256 "6658bd3c2b8813eb3e2511ee153238d09ace9d309e4574af27443d87423e4233"
-  revision 1
+  url "https://download.gnome.org/sources/gobject-introspection/1.48/gobject-introspection-1.48.0.tar.xz"
+  sha256 "fa275aaccdbfc91ec0bc9a6fd0562051acdba731e7d584b64a277fec60e75877"
 
   bottle do
     revision 1
@@ -18,17 +17,7 @@ class GobjectIntrospection < Formula
   depends_on "glib"
   depends_on "cairo"
   depends_on "libffi"
-  # System python in Mavericks or below has bug in distutils/sysconfig.py, which breaks the install.
-  #    Caught exception: <type 'exceptions.AttributeError'> AttributeError("'NoneType' object has no attribute 'get'",)
-  #    > /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/sysconfig.py(171)customize_compiler()
-  depends_on "python" if MacOS.version <= :mavericks
-
-  # see https://bugzilla.gnome.org/show_bug.cgi?id=625195
-  # to be removed when 1.48.0 is released
-  patch do
-    url "https://github.com/GNOME/gobject-introspection/commit/4a724ac699f0c34fba2fb452cfadea11540325e8.patch"
-    sha256 "047c350bad2d222f1037c3ce1889444ebc1095df76120188037c4eb2900848c4"
-  end
+  depends_on "python"
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",
@@ -43,7 +32,7 @@ class GobjectIntrospection < Formula
       s.change_make_var! "GOBJECT_INTROSPECTION_LIBDIR", "#{HOMEBREW_PREFIX}/lib"
     end
 
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}", "PYTHON=python"
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}", "PYTHON=#{HOMEBREW_PREFIX}/bin/python"
     system "make"
     system "make", "install"
   end

--- a/Library/Formula/goffice.rb
+++ b/Library/Formula/goffice.rb
@@ -1,8 +1,8 @@
 class Goffice < Formula
   desc "Gnumeric spreadsheet program"
   homepage "https://developer.gnome.org/goffice/"
-  url "https://download.gnome.org/sources/goffice/0.10/goffice-0.10.27.tar.xz"
-  sha256 "3717b400fd190f18cf1dd7a16e1991b1f7c7cbdfeb1993656e7972347168d8c0"
+  url "https://download.gnome.org/sources/goffice/0.10/goffice-0.10.28.tar.xz"
+  sha256 "068f060de1a4c058b373dbd4adbfc48fda4b4e3402ec070499d7cd1e737f3a8b"
 
   bottle do
     sha256 "8bcaebdbad7414bc4605b5f3c6e591eeff7f3b881f7f9e9c38a46fb8b4cac46e" => :el_capitan

--- a/Library/Formula/gsettings-desktop-schemas.rb
+++ b/Library/Formula/gsettings-desktop-schemas.rb
@@ -1,8 +1,8 @@
 class GsettingsDesktopSchemas < Formula
   desc "GSettings schemas for desktop components"
   homepage "https://download.gnome.org/sources/gsettings-desktop-schemas/"
-  url "https://download.gnome.org/sources/gsettings-desktop-schemas/3.18/gsettings-desktop-schemas-3.18.1.tar.xz"
-  sha256 "258713b2a3dc6b6590971bcfc81f98d78ea9827d60e2f55ffbe40d9cd0f99a1a"
+  url "https://download.gnome.org/sources/gsettings-desktop-schemas/3.20/gsettings-desktop-schemas-3.20.0.tar.xz"
+  sha256 "55a41b533c0ab955e0a36a84d73829451c88b027d8d719955d8f695c35c6d9c1"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/gspell.rb
+++ b/Library/Formula/gspell.rb
@@ -1,8 +1,8 @@
 class Gspell < Formula
   desc "Flexible API to implement spellchecking in GTK+ applications"
   homepage "https://wiki.gnome.org/Projects/gspell"
-  url "https://download.gnome.org/sources/gspell/1.0/gspell-1.0.0.tar.xz"
-  sha256 "6a50257c871c318445881c115bdd11bb8da6672f7d5b99e96c2e7b5c00f077da"
+  url "https://download.gnome.org/sources/gspell/1.0/gspell-1.0.1.tar.xz"
+  sha256 "22cd0545351801a83c0da8da5baa6755b9032654c1bea95e116458066f7bc71b"
 
   bottle do
     sha256 "c6633e8f395f042c59dfe19841413261a3735f8ce7eba52b6aac48c542ea01ed" => :el_capitan

--- a/Library/Formula/gspell.rb
+++ b/Library/Formula/gspell.rb
@@ -1,8 +1,8 @@
 class Gspell < Formula
   desc "Flexible API to implement spellchecking in GTK+ applications"
   homepage "https://wiki.gnome.org/Projects/gspell"
-  url "https://download.gnome.org/sources/gspell/0.2/gspell-0.2.3.tar.xz"
-  sha256 "e3bfa90a04f660efb1e5bcb182ee8d07d13f78817cccd006992534261b633510"
+  url "https://download.gnome.org/sources/gspell/1.0/gspell-1.0.0.tar.xz"
+  sha256 "6a50257c871c318445881c115bdd11bb8da6672f7d5b99e96c2e7b5c00f077da"
 
   bottle do
     sha256 "c6633e8f395f042c59dfe19841413261a3735f8ce7eba52b6aac48c542ea01ed" => :el_capitan
@@ -11,8 +11,12 @@ class Gspell < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gtk-mac-integration"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "enchant"
+  depends_on "gtk+3"
+  depends_on "gtk-mac-integration"
   depends_on "iso-codes"
   depends_on "vala" => :recommended
 
@@ -21,6 +25,7 @@ class Gspell < Formula
   patch :DATA
 
   def install
+    system "autoreconf", "-i"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
@@ -101,17 +106,52 @@ class Gspell < Formula
 end
 
 __END__
-diff --git a/gspell/Makefile.in b/gspell/Makefile.in
-index d97ce61..d0b6779 100644
---- a/gspell/Makefile.in
-+++ b/gspell/Makefile.in
-@@ -481,7 +481,8 @@ AM_CPPFLAGS = \
-	-I$(top_srcdir)			\
-	$(WARN_CFLAGS)			\
-	$(DEP_CFLAGS)			\
+diff --git a/gspell/Makefile.am b/gspell/Makefile.am
+index f025b4d..13c9743 100644
+--- a/gspell/Makefile.am
++++ b/gspell/Makefile.am
+@@ -11,7 +11,8 @@ AM_CPPFLAGS =				\
+ 	$(WARN_CFLAGS)			\
+ 	$(CODE_COVERAGE_CPPFLAGS)	\
+ 	$(DEP_CFLAGS)			\
 -	$(GTK_MAC_CFLAGS)
 +	$(GTK_MAC_CFLAGS)               \
 +	-xobjective-c
+ 
+ BUILT_SOURCES =			\
+ 	gspell-resources.c
+@@ -75,7 +76,13 @@ libgspell_core_la_CFLAGS = \
+ libgspell_core_la_LDFLAGS =		\
+ 	-no-undefined			\
+ 	$(WARN_LDFLAGS)			\
+-	$(CODE_COVERAGE_LDFLAGS)
++	$(CODE_COVERAGE_LDFLAGS)        \
++	-framework Cocoa -framework Foundation -framework Cocoa
++
++
++libgspell_core_la_LIBADD =		\
++	$(GTK_MAC_LIBS)
++
+ 
+ # The real library.
+ lib_LTLIBRARIES = libgspell-@GSPELL_API_VERSION@.la
+@@ -95,7 +102,8 @@ libgspell_@GSPELL_API_VERSION@_la_LDFLAGS =	\
+ 	-no-undefined				\
+ 	-export-symbols-regex "^gspell_.*"	\
+ 	$(WARN_LDFLAGS)				\
+-	$(CODE_COVERAGE_LDFLAGS)
++	$(CODE_COVERAGE_LDFLAGS)                \
++	-framework Cocoa -framework Foundation -framework Cocoa
+ 
+ libgspell_includedir = $(includedir)/gspell-@GSPELL_API_VERSION@/gspell
+ libgspell_include_HEADERS = $(gspell_public_headers)
+@@ -108,7 +116,7 @@ CLEANFILES = $(BUILT_SOURCES)
+ 
+ if OS_OSX
+ libgspell_@GSPELL_API_VERSION@_la_LDFLAGS += \
+-	-framework Cocoa
++	-framework Cocoa -framework Foundation -framework Cocoa
+ 
+ libgspell_@GSPELL_API_VERSION@_la_CFLAGS += \
+ 	-xobjective-c
 
- AM_LDFLAGS = $(WARN_LDFLAGS)
- BUILT_SOURCES = \

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,8 +1,8 @@
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "http://gtk.org/"
-  url "https://download.gnome.org/sources/gtk+/3.18/gtk+-3.18.9.tar.xz"
-  sha256 "783d7f8b00f9b4224cc94d7da885a67598e711c2d6d79c9c873c6b203e83acbd"
+  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.0.tar.xz"
+  sha256 "1c3d3a4a6e959ec8636ccb074bcdb8fa25c81ec56fbc70de6a3f5ef83ba6d803"
 
   bottle do
     sha256 "57613440207555041ff48bc234c33b0bd6c15b3548712ea3d2e080952f57d7c5" => :el_capitan
@@ -52,7 +52,7 @@ class Gtkx3 < Formula
     system "./configure", *args
     # necessary to avoid gtk-update-icon-cache not being found during make install
     bin.mkpath
-    ENV.prepend_path "PATH", "#{bin}"
+    ENV.prepend_path "PATH", bin.to_s
     system "make", "install"
     # Prevent a conflict between this and Gtk+2
     mv bin/"gtk-update-icon-cache", bin/"gtk3-update-icon-cache"

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,8 +1,8 @@
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "http://gtk.org/"
-  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.2.tar.xz"
-  sha256 "1ab1d1068ea55e0046f437d69983f164df5e68cb2e9fdfb38787b867f33f69f7"
+  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.3.tar.xz"
+  sha256 "3834f3bf23b260b3e5ebfea41102e2026a8af29e36c3620edf4a5cf05e82f694"
 
   bottle do
     sha256 "57613440207555041ff48bc234c33b0bd6c15b3548712ea3d2e080952f57d7c5" => :el_capitan

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,8 +1,8 @@
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "http://gtk.org/"
-  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.0.tar.xz"
-  sha256 "1c3d3a4a6e959ec8636ccb074bcdb8fa25c81ec56fbc70de6a3f5ef83ba6d803"
+  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.1.tar.xz"
+  sha256 "ac86a01a57b4258ea70bc85b9494b333226eda6f5a2b0716ad48cfcded5f5380"
 
   bottle do
     sha256 "57613440207555041ff48bc234c33b0bd6c15b3548712ea3d2e080952f57d7c5" => :el_capitan

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -1,8 +1,8 @@
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "http://gtk.org/"
-  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.1.tar.xz"
-  sha256 "ac86a01a57b4258ea70bc85b9494b333226eda6f5a2b0716ad48cfcded5f5380"
+  url "https://download.gnome.org/sources/gtk+/3.20/gtk+-3.20.2.tar.xz"
+  sha256 "1ab1d1068ea55e0046f437d69983f164df5e68cb2e9fdfb38787b867f33f69f7"
 
   bottle do
     sha256 "57613440207555041ff48bc234c33b0bd6c15b3548712ea3d2e080952f57d7c5" => :el_capitan

--- a/Library/Formula/gtk-doc.rb
+++ b/Library/Formula/gtk-doc.rb
@@ -1,8 +1,8 @@
 class GtkDoc < Formula
   desc "GTK+ documentation tool"
   homepage "http://www.gtk.org/gtk-doc/"
-  url "https://download.gnome.org/sources/gtk-doc/1.24/gtk-doc-1.24.tar.xz"
-  sha256 "b420759ea05c760301bada14e428f1b321f5312f44e10a176d6804822dabb58b"
+  url "https://download.gnome.org/sources/gtk-doc/1.25/gtk-doc-1.25.tar.xz"
+  sha256 "1ea46ed400e6501f975acaafea31479cea8f32f911dca4dff036f59e6464fd42"
 
   bottle do
     sha256 "7467edb24beda3fda8082721f96f3198c3165f1fc3c129a01d0f36b3e5518e8f" => :yosemite

--- a/Library/Formula/gtkmm3.rb
+++ b/Library/Formula/gtkmm3.rb
@@ -1,8 +1,8 @@
 class Gtkmm3 < Formula
   desc "C++ interfaces for GTK+ and GNOME"
   homepage "http://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/gtkmm/3.18/gtkmm-3.18.0.tar.xz"
-  sha256 "829fa113daed74398c49c3f2b7672807f58ba85d0fa463f5bc726e1b0138b86b"
+  url "https://download.gnome.org/sources/gtkmm/3.20/gtkmm-3.20.0.tar.xz"
+  sha256 "f021573f870df8a0b40ba37a7864c37be517c7a88cc957a193dbab28449b028a"
 
   bottle do
     cellar :any

--- a/Library/Formula/gtksourceview3.rb
+++ b/Library/Formula/gtksourceview3.rb
@@ -1,8 +1,8 @@
 class Gtksourceview3 < Formula
   desc "Text view with syntax, undo/redo, and text marks"
   homepage "https://projects.gnome.org/gtksourceview/"
-  url "https://download.gnome.org/sources/gtksourceview/3.20/gtksourceview-3.20.0.tar.xz"
-  sha256 "0b753cbd49cdfb0fb8bb347e4669dcc233d9c05c1d321429efe93c4e885262fd"
+  url "https://download.gnome.org/sources/gtksourceview/3.20/gtksourceview-3.20.1.tar.xz"
+  sha256 "322d95c0eaba768a47956ccf1af732ea9377ab7a8afc145b1a34a04012ae8c4c"
 
   bottle do
     sha256 "8e2a97d367acfcf94217360f793e16b8946718d3da95b88907ec1b969e7b7087" => :el_capitan

--- a/Library/Formula/gtksourceview3.rb
+++ b/Library/Formula/gtksourceview3.rb
@@ -1,8 +1,8 @@
 class Gtksourceview3 < Formula
   desc "Text view with syntax, undo/redo, and text marks"
   homepage "https://projects.gnome.org/gtksourceview/"
-  url "https://download.gnome.org/sources/gtksourceview/3.18/gtksourceview-3.18.2.tar.xz"
-  sha256 "60f75a9f0039e13a2281fc595b5ef7344afa06732cc53b57d13234bfb0a5b7b2"
+  url "https://download.gnome.org/sources/gtksourceview/3.20/gtksourceview-3.20.0.tar.xz"
+  sha256 "0b753cbd49cdfb0fb8bb347e4669dcc233d9c05c1d321429efe93c4e885262fd"
 
   bottle do
     sha256 "8e2a97d367acfcf94217360f793e16b8946718d3da95b88907ec1b969e7b7087" => :el_capitan

--- a/Library/Formula/json-glib.rb
+++ b/Library/Formula/json-glib.rb
@@ -1,8 +1,8 @@
 class JsonGlib < Formula
   desc "Library for JSON, based on GLib"
   homepage "https://live.gnome.org/JsonGlib"
-  url "https://download.gnome.org/sources/json-glib/1.0/json-glib-1.0.4.tar.xz"
-  sha256 "80f3593cb6bd13f1465828e46a9f740e2e9bd3cd2257889442b3e62bd6de05cd"
+  url "https://download.gnome.org/sources/json-glib/1.2/json-glib-1.2.0.tar.xz"
+  sha256 "99d6dfbe49c08fd7529f1fe8dcb1893b810a1bb222f1e7b65f41507658b8a7d3"
 
   bottle do
     sha256 "08cf8e09c827d20869eb11b6a5422caf49a291142dc3c403cc4392b15d03d1fb" => :el_capitan

--- a/Library/Formula/libgit2-glib.rb
+++ b/Library/Formula/libgit2-glib.rb
@@ -1,8 +1,8 @@
 class Libgit2Glib < Formula
   desc "Glib wrapper library around libgit2 git access library"
   homepage "https://github.com/GNOME/libgit2-glib"
-  url "https://download.gnome.org/sources/libgit2-glib/0.23/libgit2-glib-0.23.10.tar.xz"
-  sha256 "398ea6ff5fb1eafa61f2908da5ff8722dc051a2081be6cbed76a2ab07ecab1af"
+  url "https://download.gnome.org/sources/libgit2-glib/0.24/libgit2-glib-0.24.0.tar.xz"
+  sha256 "d616c268821c28ff8dc1a6419dbf8555fa48e31dc6509c10f5151be7690f4845"
 
   bottle do
     sha256 "e1707622fa3434b1bec14221080022534fa830f6eaf9ecc97581e39ce4460dcf" => :el_capitan

--- a/Library/Formula/libgit2.rb
+++ b/Library/Formula/libgit2.rb
@@ -1,8 +1,8 @@
 class Libgit2 < Formula
   desc "C library of Git core methods that is re-entrant and linkable"
   homepage "https://libgit2.github.com/"
-  url "https://github.com/libgit2/libgit2/archive/v0.23.4.tar.gz"
-  sha256 "c7f5e2d7381dbc4d7e878013d14f9993ae8a41bd23f032718e39ffba57894029"
+  url "https://github.com/libgit2/libgit2/archive/v0.24.0.tar.gz"
+  sha256 "1c6693f943bee3f634b9094376f93e7e03b9ca77354a33f4e903fdcb2ee8b2b0"
   head "https://github.com/libgit2/libgit2.git"
 
   bottle do

--- a/Library/Formula/libgtop.rb
+++ b/Library/Formula/libgtop.rb
@@ -1,8 +1,8 @@
 class Libgtop < Formula
   desc "Library for portably obtaining information about processes"
   homepage "https://library.gnome.org/devel/libgtop/stable/"
-  url "https://download.gnome.org/sources/libgtop/2.32/libgtop-2.32.0.tar.xz"
-  sha256 "8443246332f22b33e389f565825b58cd9623fb7625bf874d404354b705ad178e"
+  url "https://download.gnome.org/sources/libgtop/2.34/libgtop-2.34.0.tar.xz"
+  sha256 "8d8ae39e700d1c8c0b3e1391ed10ca88e6fc14f49d175d516dab6e3313b4ee2a"
 
   bottle do
     sha256 "6ef8bfd87b331fd871f5e3e0b8d915a39597a3c928c3c2d7393ebf402347c620" => :el_capitan

--- a/Library/Formula/libgweather.rb
+++ b/Library/Formula/libgweather.rb
@@ -1,8 +1,8 @@
 class Libgweather < Formula
   desc "GNOME library for weather, locations and timezones"
   homepage "https://wiki.gnome.org/Projects/LibGWeather"
-  url "https://download.gnome.org/sources/libgweather/3.18/libgweather-3.18.1.tar.xz"
-  sha256 "94b2292f8f7616e2aa81b1516befd7b27682b20acecbd5d656b6954990ca7ad0"
+  url "https://download.gnome.org/sources/libgweather/3.20/libgweather-3.20.0.tar.xz"
+  sha256 "52629b8e9fcd979377f43a2223cf0e7096d3c3e940faa94021132ee0f879b8d6"
 
   bottle do
     sha256 "e2b7853e95cf104ccd5f3cff216336077d77e671349b1734f7b4c3a4f0773fba" => :el_capitan

--- a/Library/Formula/libpeas.rb
+++ b/Library/Formula/libpeas.rb
@@ -1,8 +1,8 @@
 class Libpeas < Formula
   desc "GObject plugin library"
   homepage "https://developer.gnome.org/libpeas/stable/"
-  url "https://download.gnome.org/sources/libpeas/1.16/libpeas-1.16.0.tar.xz"
-  sha256 "b093008ecd65f7d55c80517589509698ff15ad41f664b11a3eb88ff461b1454e"
+  url "https://download.gnome.org/sources/libpeas/1.18/libpeas-1.18.0.tar.xz"
+  sha256 "bf49842c64c36925bbc41d954de490b6ff7faa29b45f6fd9e91ddcc779165e26"
 
   bottle do
     sha256 "fc930781e9c52420acfb590e634551230a2cb0682c904a1466844d0fc0e04673" => :el_capitan
@@ -13,20 +13,12 @@ class Libpeas < Formula
   depends_on "pkg-config" => :build
   depends_on "intltool" => :build
   depends_on "gettext" => :build
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "gnome-common" => :build
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
 
-  # fixes a linking issue in the tests
-  # submitted upsteam as a PR: https://github.com/gregier/libpeas/pull/3
-  patch :DATA
-
   def install
-    system "autoreconf", "-i"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
@@ -72,19 +64,3 @@ class Libpeas < Formula
     system "./test"
   end
 end
-
-__END__
-diff --git a/tests/libpeas/plugins/extension-c/Makefile.am b/tests/libpeas/plugins/extension-c/Makefile.am
-index 9f18008..ed51b06 100644
---- a/tests/libpeas/plugins/extension-c/Makefile.am
-+++ b/tests/libpeas/plugins/extension-c/Makefile.am
-@@ -18,7 +18,8 @@ libextension_c_la_SOURCES = \
- libextension_c_la_LDFLAGS = $(TEST_PLUGIN_LIBTOOL_FLAGS)
- libextension_c_la_LIBADD = \
-	$(PEAS_LIBS)						\
--	$(builddir)/../../introspection/libintrospection-1.0.la
-+	$(builddir)/../../introspection/libintrospection-1.0.la \
-+	$(top_builddir)/libpeas/libpeas-1.0.la
-
- libextension_c_missing_symbol_la_SOURCES = \
-	extension-c-missing-symbol-plugin.c

--- a/Library/Formula/librsvg.rb
+++ b/Library/Formula/librsvg.rb
@@ -3,6 +3,7 @@ class Librsvg < Formula
   homepage "https://live.gnome.org/LibRsvg"
   url "https://download.gnome.org/sources/librsvg/2.40/librsvg-2.40.13.tar.xz"
   sha256 "4d6ea93ec05f5dabe7262d711d246a0a99b2311e215360dd3dcabd6afe3b9804"
+  revision 1
 
   bottle do
     sha256 "d17e2b85ffb9fd05850a8c9a5e74ef4fa478a514bb2f49758b735f22fbb14e34" => :el_capitan

--- a/Library/Formula/librsvg.rb
+++ b/Library/Formula/librsvg.rb
@@ -1,9 +1,8 @@
 class Librsvg < Formula
   desc "Library to render SVG files using Cairo"
   homepage "https://live.gnome.org/LibRsvg"
-  url "https://download.gnome.org/sources/librsvg/2.40/librsvg-2.40.13.tar.xz"
-  sha256 "4d6ea93ec05f5dabe7262d711d246a0a99b2311e215360dd3dcabd6afe3b9804"
-  revision 1
+  url "https://download.gnome.org/sources/librsvg/2.40/librsvg-2.40.15.tar.xz"
+  sha256 "d9cac4a123eec6e553a26e120979bab7425def9ae7ce7c079eba5e4a45db05f4"
 
   bottle do
     sha256 "d17e2b85ffb9fd05850a8c9a5e74ef4fa478a514bb2f49758b735f22fbb14e34" => :el_capitan

--- a/Library/Formula/libsecret.rb
+++ b/Library/Formula/libsecret.rb
@@ -1,8 +1,8 @@
 class Libsecret < Formula
   desc "Library for storing/retrieving passwords and other secrets"
   homepage "https://wiki.gnome.org/Projects/Libsecret"
-  url "https://download.gnome.org/sources/libsecret/0.18/libsecret-0.18.4.tar.xz"
-  sha256 "0f29b51698198e6999c91f4adce3119c8c457f546b133a85baea5ea9010a19ed"
+  url "https://download.gnome.org/sources/libsecret/0.18/libsecret-0.18.5.tar.xz"
+  sha256 "9ce7bd8dd5831f2786c935d82638ac428fa085057cc6780aba0e39375887ccb3"
 
   bottle do
     sha256 "4d726f0a13c77ba0db1be9a8e6a033af5908e0dea0733ac20ec19bbf34d621b2" => :el_capitan

--- a/Library/Formula/libsoup.rb
+++ b/Library/Formula/libsoup.rb
@@ -1,9 +1,8 @@
 class Libsoup < Formula
   desc "HTTP client/server library for GNOME"
   homepage "https://live.gnome.org/LibSoup"
-  url "https://download.gnome.org/sources/libsoup/2.52/libsoup-2.52.2.tar.xz"
-  sha256 "db55628b5c7d952945bb71b236469057c8dfb8dea0c271513579c6273c2093dc"
-  revision 1
+  url "https://download.gnome.org/sources/libsoup/2.54/libsoup-2.54.0.tar.xz"
+  sha256 "fbf1038efb10d2ffbbb88bb46e7ce32b683fde8e566f36bcf26f7f69a550ec56"
 
   bottle do
     sha256 "de28079d444082ea4f6f2aca4388152aa8d303926917baa5f656bdd7d222ef72" => :el_capitan
@@ -25,8 +24,8 @@ class Libsoup < Formula
       "--disable-dependency-tracking",
       "--disable-silent-rules",
       "--prefix=#{prefix}",
-      "--without-gnome",
       "--disable-tls-check",
+      "--enable-introspection=yes",
     ]
 
     # ensures that the vala files remain within the keg

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -3,8 +3,8 @@ class Pango < Formula
   homepage "http://www.pango.org/"
 
   stable do
-    url "https://download.gnome.org/sources/pango/1.40/pango-1.40.0.tar.xz"
-    sha256 "da17985df314cb07d066ab5424f59c21ce973ece05b7de4df04d798ec8511c8b"
+    url "https://download.gnome.org/sources/pango/1.40/pango-1.40.1.tar.xz"
+    sha256 "e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40"
   end
 
   bottle do

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -3,8 +3,8 @@ class Pango < Formula
   homepage "http://www.pango.org/"
 
   stable do
-    url "https://download.gnome.org/sources/pango/1.38/pango-1.38.1.tar.xz"
-    sha256 "1320569f6c6d75d6b66172b2d28e59c56ee864ee9df202b76799c4506a214eb7"
+    url "https://download.gnome.org/sources/pango/1.40/pango-1.40.0.tar.xz"
+    sha256 "da17985df314cb07d066ab5424f59c21ce973ece05b7de4df04d798ec8511c8b"
   end
 
   bottle do

--- a/Library/Formula/pangomm.rb
+++ b/Library/Formula/pangomm.rb
@@ -1,8 +1,8 @@
 class Pangomm < Formula
   desc "C++ interface to Pango"
   homepage "http://www.pango.org/"
-  url "https://download.gnome.org/sources/pangomm/2.38/pangomm-2.38.1.tar.xz"
-  sha256 "effb18505b36d81fc32989a39ead8b7858940d0533107336a30bc3eef096bc8b"
+  url "https://download.gnome.org/sources/pangomm/2.40/pangomm-2.40.0.tar.xz"
+  sha256 "7dd0afa9dcce57cdb0aad77da9ea46823ee8515d5f3ffd895b9ede7365c3d70d"
 
   bottle do
     cellar :any

--- a/Library/Formula/pygobject3.rb
+++ b/Library/Formula/pygobject3.rb
@@ -1,8 +1,8 @@
 class Pygobject3 < Formula
   desc "GLib/GObject/GIO Python bindings for Python 3"
   homepage "https://live.gnome.org/PyGObject"
-  url "https://download.gnome.org/sources/pygobject/3.18/pygobject-3.18.2.tar.xz"
-  sha256 "2a3cad1517916b74e131e6002c3824361aee0671ffb0d55ded119477fc1c2c5f"
+  url "https://download.gnome.org/sources/pygobject/3.20/pygobject-3.20.0.tar.xz"
+  sha256 "31ab4701f40490082aa98af537ccddba889577abe66d242582f28577e8807f46"
 
   bottle do
     sha256 "28dd19d1d32f8890d246b0e98fbb788438ee753f85e880eb754044752bc3e322" => :el_capitan

--- a/Library/Formula/vala.rb
+++ b/Library/Formula/vala.rb
@@ -1,18 +1,13 @@
 class Vala < Formula
   desc "Compiler for the GObject type system"
   homepage "https://live.gnome.org/Vala"
-  url "https://download.gnome.org/sources/vala/0.30/vala-0.30.1.tar.xz"
-  sha256 "23add78e5c6a5e6df019d4a885c9c79814c9e0b957519ec8a4f4d826c4e5df2c"
+  url "https://download.gnome.org/sources/vala/0.32/vala-0.32.0.tar.xz"
+  sha256 "07a2aa4ede040789b4b5af817a42249d703bfe8affccb7732ca2b53d00c1fb6e"
 
   bottle do
     sha256 "b68681f676381035cdd85e944aa234f0566137bda514ec105477fbeed246a365" => :el_capitan
     sha256 "752fe91460002b335c35084f073d6e3f3666017f6b7dea9f728a828a0dde911e" => :yosemite
     sha256 "bf422cf5802d09413482943afac7cd0b7d19e2defa1955330acb11d644d61299" => :mavericks
-  end
-
-  devel do
-    url "https://download.gnome.org/sources/vala/0.31/vala-0.31.1.tar.xz"
-    sha256 "c3cbff1cc29f3fca3939c3994b8591ec3d9aca4d85d042353ee46c00ddf4055f"
   end
 
   depends_on "pkg-config" => :run

--- a/Library/Formula/valabind.rb
+++ b/Library/Formula/valabind.rb
@@ -3,6 +3,7 @@ class Valabind < Formula
   homepage "http://radare.org/"
   url "http://www.radare.org/get/valabind-0.10.0.tar.gz"
   sha256 "35517455b4869138328513aa24518b46debca67cf969f227336af264b8811c19"
+  revision 1
 
   head "https://github.com/radare/valabind.git"
 

--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -1,8 +1,8 @@
 class Vte3 < Formula
   desc "Terminal emulator widget used by GNOME terminal"
   homepage "https://developer.gnome.org/vte/"
-  url "https://download.gnome.org/sources/vte/0.44/vte-0.44.0.tar.xz"
-  sha256 "93a3b1a71a885f416a119a5a8fb27b8f36bb176b8d0bec5e48188d1db5ef12aa"
+  url "https://download.gnome.org/sources/vte/0.44/vte-0.44.1.tar.xz"
+  sha256 "712dd548339f600fd7e221d12b2670a13a4361b2cd23ba0e057e76cc19fe5d4e"
 
   bottle do
     sha256 "db7a446cd050e27b05f0fe762c6368ba2462b47a3bc547c367a442ebe7266b86" => :el_capitan

--- a/Library/Formula/vte3.rb
+++ b/Library/Formula/vte3.rb
@@ -1,8 +1,8 @@
 class Vte3 < Formula
   desc "Terminal emulator widget used by GNOME terminal"
   homepage "https://developer.gnome.org/vte/"
-  url "https://download.gnome.org/sources/vte/0.42/vte-0.42.4.tar.xz"
-  sha256 "08c88bf5c0aa1dfa3711e2e83b784fb5ea82025661f30b54e93eebd5f4bce113"
+  url "https://download.gnome.org/sources/vte/0.44/vte-0.44.0.tar.xz"
+  sha256 "93a3b1a71a885f416a119a5a8fb27b8f36bb176b8d0bec5e48188d1db5ef12aa"
 
   bottle do
     sha256 "db7a446cd050e27b05f0fe762c6368ba2462b47a3bc547c367a442ebe7266b86" => :el_capitan

--- a/Library/Formula/yelp-xsl.rb
+++ b/Library/Formula/yelp-xsl.rb
@@ -1,8 +1,8 @@
 class YelpXsl < Formula
   desc "Yelp's universal stylesheets for Mallard and DocBook"
   homepage "https://github.com/GNOME/yelp-xsl"
-  url "https://download.gnome.org/sources/yelp-xsl/3.18/yelp-xsl-3.18.1.tar.xz"
-  sha256 "00870fbe59a1bc7797b385fce16386917e2987c404e9b5a7adcf0036f1c1ba62"
+  url "https://download.gnome.org/sources/yelp-xsl/3.20/yelp-xsl-3.20.0.tar.xz"
+  sha256 "9f327887853c40d7332dde8789ee58c0cf678186719cb905e57ae175b8434848"
 
   bottle do
     cellar :any_skip_relocation
@@ -31,9 +31,9 @@ class YelpXsl < Formula
   end
 
   test do
-    assert (share/"yelp-xsl/xslt/mallard/html/mal2html-links.xsl").exist?
-    assert (share/"yelp-xsl/js/jquery.syntax.brush.smalltalk.js").exist?
-    assert (share/"yelp-xsl/icons/hicolor/24x24/status/yelp-note-warning.png").exist?
+    assert (pkgshare/"xslt/mallard/html/mal2html-links.xsl").exist?
+    assert (pkgshare/"js/jquery.syntax.brush.smalltalk.js").exist?
+    assert (pkgshare/"icons/hicolor/24x24/status/yelp-note-warning.png").exist?
     assert (share/"pkgconfig/yelp-xsl.pc").exist?
   end
 end

--- a/Library/Formula/yelp-xsl.rb
+++ b/Library/Formula/yelp-xsl.rb
@@ -1,8 +1,8 @@
 class YelpXsl < Formula
   desc "Yelp's universal stylesheets for Mallard and DocBook"
   homepage "https://github.com/GNOME/yelp-xsl"
-  url "https://download.gnome.org/sources/yelp-xsl/3.20/yelp-xsl-3.20.0.tar.xz"
-  sha256 "9f327887853c40d7332dde8789ee58c0cf678186719cb905e57ae175b8434848"
+  url "https://download.gnome.org/sources/yelp-xsl/3.20/yelp-xsl-3.20.1.tar.xz"
+  sha256 "dc61849e5dca473573d32e28c6c4e3cf9c1b6afe241f8c26e29539c415f97ba0"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/zenity.rb
+++ b/Library/Formula/zenity.rb
@@ -1,8 +1,8 @@
 class Zenity < Formula
   desc "GTK+ dialog boxes for the command-line"
   homepage "https://live.gnome.org/Zenity"
-  url "https://download.gnome.org/sources/zenity/3.18/zenity-3.18.1.tar.xz"
-  sha256 "089d45f8e82bb48ae80fcb78693bcd7a29579631234709d752afed6c5a107ba8"
+  url "https://download.gnome.org/sources/zenity/3.20/zenity-3.20.0.tar.xz"
+  sha256 "02e8759397f813c0a620b93ebeacdab9956191c9dc0d0fcba1815c5ea3f15a48"
 
   bottle do
     sha256 "f0017ba4ecdcdb89d8339ea2efefed1c1d7753544899cde824cd59864761710e" => :el_capitan
@@ -17,12 +17,10 @@ class Zenity < Formula
   depends_on "gtk+3"
   depends_on "gnome-doc-utils"
   depends_on "scrollkeeper"
+  depends_on "webkitgtk" => :recommended
 
-  # submitted upstream at https://bugzilla.gnome.org/show_bug.cgi?id=756756
-  patch :DATA
 
   def install
-    ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python2.7/site-packages"
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
@@ -32,21 +30,3 @@ class Zenity < Formula
     system "#{bin}/zenity", "--help"
   end
 end
-
-__END__
-diff --git a/src/option.c b/src/option.c
-index 79a6f92..246cf22 100644
---- a/src/option.c
-+++ b/src/option.c
-@@ -2074,9 +2074,11 @@ zenity_text_post_callback (GOptionContext *context,
-     if (zenity_text_font)
-       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_font),
-                            ERROR_SUPPORT);
-+#ifdef HAVE_WEBKITGTK
-     if (zenity_text_enable_html)
-       zenity_option_error (zenity_option_get_name (text_options, &zenity_text_enable_html),
-                            ERROR_SUPPORT);
-+#endif
-   }
-   return TRUE;
- }


### PR DESCRIPTION
Over the next 3 days, Gnome 3.20 will be released which will include about 30-40 packages that can be identified by their download url `https://download.gnome.org/sources/`.

As with previous Gnome releases, I will create one PR for all of them as it makes it a lot easier to do with dependencies between the different packages.

Please do not accept other PRs in the meantime that would update Gnome packages...

Here follows an (incomplete) list of packages that will see updates:

- [x] glib
- [ ] cairo??
- [x] pango
- [x] gtk+3 -> already at 3.20.1
- [x] gdk-pixbuf
- [x] anjuta
- [x] at-spi2-atk
- [x] at-spi2-core
- [x] atk
- [ ] atkmm
- [x] baobab
- [ ] cairomm
- [x] clutter-gst
- [x] clutter-gtk
- [x] clutter
- [ ] cogl
- [x] devhelp
- [x] evince -> but unusable as most widgets are not rendered (reported upstream)
- [ ] file-roller
- [x] gdl -> 3.20.0 done!
- [x] gedit -> but very buggy: no menubar! (reported upstream)
- [x] all gstreamer packages -> see #50408 
- [x] geocode-glib
- [ ] ghex
- [x] gitg
- [ ] gjs
- [x] glade3
- [x] glib-networking
- [ ] glibmm
- [x] gnome-builder
- [ ] gnome-common
- [x] gnome-icon-theme (adwaita-icon-theme)
- [x] gnome-themes-standard
- [x] gnumeric
- [x] gobject-introspection
- [x] goffice
- [ ] graphene
- [x] gsettings-desktop-schemas
- [x] gspell
- [ ] gtkmm3
- [x] gtksourceview3
- [ ] gtksourceviewmm3
- [x] gtk-doc
- [x] gucharmap -> 8.0.0 was released but I did not manage to install it. Badly broken
- [x] json-glib
- [ ] libcroco
- [ ] libgee
- [x] libgit2-glib see #49930 
- [x] libgtop
- [x] libgweather
- [x] libpeas
- [x] libsecret
- [ ] librsvg
- [x] pygobject3
- [x] vala
- [x] vte3
- [x] yelp-xsl
- [ ] webkitgtk
- [x] zenity
...