### PR TITLE
missing: add quiet and json

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -1,39 +1,29 @@
 require "formula"
 require "keg"
+require "formula_printer"
 
 module Homebrew
   def outdated
-    formulae = ARGV.resolved_formulae.any? ? ARGV.resolved_formulae : Formula.installed
-    if ARGV.json == "v1"
-      outdated = print_outdated_json(formulae)
-    else
-      outdated = print_outdated(formulae)
-    end
-    Homebrew.failed = ARGV.resolved_formulae.any? && outdated.any?
+    OutdatedFormulaePrinter.print
   end
 
-  def print_outdated(formulae)
-    verbose = ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
+  class OutdatedFormulaePrinter < FormulaPrinter
+    def selection
+      @domain.select(&:outdated?)
+    end
 
-    formulae.select(&:outdated?).each do |f|
-      if verbose
+    def print_verbose
+      @selection.each do |f|
         puts "#{f.full_name} (#{f.outdated_versions*", "} < #{f.pkg_version})"
-      else
-        puts f.full_name
       end
     end
-  end
 
-  def print_outdated_json(formulae)
-    json = []
-    outdated = formulae.select(&:outdated?).each do |f|
-
-      json << { :name => f.full_name,
-                :installed_versions => f.outdated_versions.collect(&:to_s),
-                :current_version => f.pkg_version.to_s }
+    def json
+      @selection.map do |f|
+        { :name => f.full_name,
+          :installed_versions => f.outdated_versions.collect(&:to_s),
+          :current_version => f.pkg_version.to_s }
+      end
     end
-    puts Utils::JSON.dump(json)
-
-    outdated
   end
 end

--- a/Library/Homebrew/formula_printer.rb
+++ b/Library/Homebrew/formula_printer.rb
@@ -1,0 +1,72 @@
+require "formula"
+require "tab"
+require "diagnostic"
+
+module Homebrew
+  class FormulaPrinter
+    attr_reader :domain, :selection
+
+    def initialize
+      @domain = domain
+      @selection = selection
+    end
+
+    def selection
+      raise "method missing"
+    end
+
+    def domain
+      if ARGV.named.empty?
+        Formula.installed
+      else
+        ARGV.resolved_formulae
+      end
+    end
+
+    def self.print
+      return unless HOMEBREW_CELLAR.exist?
+      printer = new
+      if ARGV.json == "v1"
+        printer.print_json
+      elsif ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
+        printer.print_verbose
+      else
+        printer.print_quiet
+      end
+      printer.exit_status
+    end
+
+    def exit_status
+      Homebrew.failed = @selection.any?
+    end
+
+    def quiet
+      @selection.class == Hash ? @selection.values.flatten.uniq : @selection
+    end
+
+    def print_quiet
+      full_names = quiet.map(&:full_name).sort do |a, b|
+        if a.include?("/") && !b.include?("/")
+          1
+        elsif !a.include?("/") && b.include?("/")
+          -1
+        else
+          a <=> b
+        end
+      end
+      puts_columns full_names
+    end
+
+    def print_verbose
+      raise "method missing"
+    end
+
+    def json
+      raise "method missing"
+    end
+
+    def print_json
+      puts Utils::JSON.dump(json)
+    end
+  end
+end

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -299,10 +299,21 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Show the git log for the given formulae. Options that `git-log`(1)
     recognizes can be passed before the formula list.
 
-  * `missing` [<formulae>]:
+  * `missing` [`--quiet`|`--verbose`|`--json=v1`] [<formulae>]:
     Check the given <formulae> for missing dependencies.
 
     If no <formulae> are given, check all installed brews.
+
+    By default, missing formulae are displayed as per-formula lists in
+    interactive shells, and as a single, non-repeating list otherwise.
+
+    If `--quiet` is passed, list only the names of missing brews (takes
+    precedence over `--verbose`.
+
+    If `--verbose` is passed, display per-formula lists of missing brews.
+
+    If `--json=`<version> is passed, the output will be in JSON format. The only
+    valid version is `v1`.
 
   * `migrate` [`--force`] <formulae>:
     Migrate renamed packages to new name, where <formulae> are old names of

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -244,7 +244,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     EOS
 
     (HOMEBREW_CELLAR/"bar/1.0").mkpath
-    assert_match "foo", cmd("missing")
+    assert_match "foo", cmd_fail("missing")
   ensure
     (HOMEBREW_CELLAR/"bar").rmtree
     foo_file.unlink

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -386,7 +386,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     EOS
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
-    assert_equal "testball", cmd("outdated")
+    assert_equal "testball", cmd_fail("outdated")
   ensure
     formula_file.unlink
     FileUtils.rm_rf HOMEBREW_CELLAR/"testball"

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -237,9 +237,20 @@ specified (pinned) formulae if <var>formulae</var> are given.
 See also <code>pin</code>, <code>unpin</code>.</p></dd>
 <dt><code>log</code> [<code>git-log-options</code>] <var>formula</var> ...</dt><dd><p>Show the git log for the given formulae. Options that <code>git-log</code>(1)
 recognizes can be passed before the formula list.</p></dd>
-<dt><code>missing</code> [<var>formulae</var>]</dt><dd><p>Check the given <var>formulae</var> for missing dependencies.</p>
+<dt><code>missing</code> [<code>--quiet</code>|<code>--verbose</code>|<code>--json=v1</code>] [<var>formulae</var>]</dt><dd><p>Check the given <var>formulae</var> for missing dependencies.</p>
 
-<p>If no <var>formulae</var> are given, check all installed brews.</p></dd>
+<p>If no <var>formulae</var> are given, check all installed brews.</p>
+
+<p>By default, missing formulae are displayed as per-formula lists in
+interactive shells, and as a single, non-repeating list otherwise.</p>
+
+<p>If <code>--quiet</code> is passed, list only the names of missing brews (takes
+precedence over <code>--verbose</code>.</p>
+
+<p>If <code>--verbose</code> is passed, display per-formula lists of missing brews.</p>
+
+<p>If <code>--json=</code><var>version</var> is passed, the output will be in JSON format. The only
+valid version is <code>v1</code>.</p></dd>
 <dt><code>migrate</code> [<code>--force</code>] <var>formulae</var></dt><dd><p>Migrate renamed packages to new name, where <var>formulae</var> are old names of
 packages.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "January 2016" "Homebrew" "brew"
+.TH "BREW" "1" "March 2016" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for OS X
@@ -317,11 +317,23 @@ If \fB\-\-pinned\fR is passed, show the versions of pinned formulae, or only the
 Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recognizes can be passed before the formula list\.
 .
 .TP
-\fBmissing\fR [\fIformulae\fR]
+\fBmissing\fR [\fB\-\-quiet\fR|\fB\-\-verbose\fR|\fB\-\-json=v1\fR] [\fIformulae\fR]
 Check the given \fIformulae\fR for missing dependencies\.
 .
 .IP
 If no \fIformulae\fR are given, check all installed brews\.
+.
+.IP
+By default, missing formulae are displayed as per\-formula lists in interactive shells, and as a single, non\-repeating list otherwise\.
+.
+.IP
+If \fB\-\-quiet\fR is passed, list only the names of missing brews (takes precedence over \fB\-\-verbose\fR\.
+.
+.IP
+If \fB\-\-verbose\fR is passed, display per\-formula lists of missing brews\.
+.
+.IP
+If \fB\-\-json=\fR\fIversion\fR is passed, the output will be in JSON format\. The only valid version is \fBv1\fR\.
 .
 .TP
 \fBmigrate\fR [\fB\-\-force\fR] \fIformulae\fR


### PR DESCRIPTION
- default is verbose, unless the output is going to a pipe, in which
  case the default is quiet (cf. `outdated`)
- verbose is almost the same as the pre-existing `missing` output, with
  the only change being that both the dependent and dependency are
  printed as `full_name` instead of the current behavior, which prints
  the dependent as `full_name` and the dependency as `name`
- quiet outputs a single, non-repeating list of missing formulae, each
  printed as its `full_name`
- json outputs the same information as verbose, one entry per dependent
  with a missing dependency, each entry containing the dependent itself
  associated with the key "name" and its dependencies in an array mapped
  to the key "missing"

