### PR TITLE
rmlint 2.4.3 (new formula)

### DIFF
--- a/Library/Formula/rmlint.rb
+++ b/Library/Formula/rmlint.rb
@@ -1,0 +1,28 @@
+class Rmlint < Formula
+  desc "remove duplicates and lint from your filesystem"
+  homepage "http://rmlint.rtfd.org"
+  url "https://github.com/sahib/rmlint/archive/v2.4.3.tar.gz"
+  sha256 "499c38449038c30b7704760d1251f0098fb28f6037e54c434ef24d6d18d0b5a5"
+
+  depends_on "glib" => :build
+  depends_on "scons" => :build
+  depends_on "gettext" => [:build, :recommended]
+  depends_on "sphinx" => [:build, :optional]
+  depends_on "gtk+" => :recommended # for gui
+  depends_on "PyGObject" => :recommended # for gui
+  depends_on "libelf" => :optional
+
+  def install
+    scons
+    bin.install("rmlint")
+  end
+
+  test do
+    system "echo just a test text >> test1.txt"
+    system "echo just a test text >> test2.txt"
+    system "rmlint"
+    system "./rmlint.sh", "-d"
+
+    assert (File.exist?("test1.txt") ^ File.exist?("test2.txt"))
+  end
+end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### New Formulae Submissions:

- [x] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Created rmlint formula. rmlint is a fast tool to remove duplicates and other lint from filesystems (https://github.com/sahib/rmlint)