### PR TITLE
htop: fix build dependencies and add --HEAD option

### DIFF
--- a/Library/Formula/htop.rb
+++ b/Library/Formula/htop.rb
@@ -1,26 +1,25 @@
 class Htop < Formula
   desc "Improved top (interactive process viewer)"
-  homepage "https://github.com/hishamhm/htop"
-  url "https://github.com/hishamhm/htop/archive/2.0.1.tar.gz"
-  sha256 "636c1e8b703058e793e8d25423af4b74059290ef9e48fa261ba58555069517b5"
+  homepage "http://hisham.hm/htop/"
+  url "http://hisham.hm/htop/releases/2.0.1/htop-2.0.1.tar.gz"
+  sha256 "f410626dfaf6b70fdf73cd7bb33cae768869707028d847fed94a978e974f5666"
 
-  bottle do
-    sha256 "b8afe978bc97ef2d18767c769941b81e0501c20566d2427e2e421bb69ca94e5a" => :el_capitan
-    sha256 "f667485b77c96a1c7fe4923858cb60f1d5700412a1921dd9a12ac4fb50f305f2" => :yosemite
-    sha256 "47fd6612ee8889637c3aa47a6c8cdc5812b8b8f8fa4853f35f2131bb8da43884" => :mavericks
+  head do
+    url "https://github.com/hishamhm/htop.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   option "with-ncurses", "Build using homebrew ncurses (enables mouse scroll)"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "homebrew/dupes/ncurses" => :optional
 
   conflicts_with "htop-osx", :because => "both install an `htop` binary"
 
   def install
-    system "./autogen.sh"
+    system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

htop don't need autoconf, automake and libtool on release tarball.