### PR TITLE
Use PostgreSQL's opt_lib as libpq_builddir

### DIFF
--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -75,6 +75,17 @@ class Postgresql < Formula
       ENV.append %w[CFLAGS LDFLAGS], "-arch #{Hardware::CPU.arch_32_bit}"
     end
 
+    # When extensions request to be build against libpq, they will compile
+    # against the Homebrew PostgreSQL's headers, but because the libdir is
+    # set to /usr/local/lib, the superenv's argument refurbishment will move
+    # the relevant -L argument to the end of the linker argument list. This
+    # results in linking against OS X's libpq, which is not in sync with the
+    # headers provided by Homebrew's PostgreSQL. Simply changing the value
+    # of libpq_builddir to opt_lib ensures refurbishment will not touch it.
+    inreplace "src/Makefile.global.in",
+              "libpq_builddir = $(libdir)",
+              "libpq_builddir = #{opt_lib}"
+
     system "./configure", *args
     system "make"
     system "make", "install-world", "datadir=#{pkgshare}",


### PR DESCRIPTION
While working on a new formula for a PostgreSQL extension, I kept getting linker errors related to `libpq` symbols. After some discussion, I realized that Homebrew's superenv argument refurbishment was breaking up the `-L/usr/local/lib -lpq` pair added by PGXS when an extension requests to be build against `libpq`.

The issue is that `pg_config --libdir` returns `/usr/local/lib`, which Homebrew happily moves to the end of the linker invocation, as `/usr/local/lib` is specially recognized by refurbishment as needing to be moved.

I initially discussed changing the `libdir` used by Homebrew's PostgreSQL, but found that could cause substantial problems. In particular, other Homebrew formulas (such as [`postgis`](https://github.com/Homebrew/homebrew/blob/fe0c3127d088921a7adaaa9429bb110ff48fac3f/Library/Formula/postgis.rb#L95), [`pgrouting`](https://github.com/Homebrew/homebrew/blob/fe0c3127d088921a7adaaa9429bb110ff48fac3f/Library/Formula/pgrouting.rb#L29), and [`pgroonga`](https://github.com/Homebrew/homebrew/blob/fe0c3127d088921a7adaaa9429bb110ff48fac3f/Library/Formula/pgroonga.rb#L23)) do _not_ ask `pg_config` where to install their libraries, but instead just use `lib.install` to add their compiled libraries.

So since other extensions naïvely use `lib.install` to symlink libraries, and PostgreSQL is currently build to expect that these libraries are in `/usr/local/lib` (or whatever the prefix is), changing the `libdir` will break any existing installs.

I also considered adding `-L#{opt_lib}` to the `LDFLAGS` used by PostgreSQL itself (as they are inherited during extension compilation), but that seemed incorrect/overkill.

Ultimately, I found that simply changing the `Makefile` variable which defines how to link against `libpq` was the simplest change. PostgreSQL extensions which don't need this functionality are not affected whatsoever, and those which do need it will "just work" without any effort (i.e. `make; make install` will be sufficient).

Sorry for the long prelude, but there were a lot of dead ends in exploring this.

Fixes Homebrew/homebrew#49948
