### PR TITLE
cpp-netlib 0.12.0-rc2

### DIFF
--- a/Library/Formula/cpp-netlib.rb
+++ b/Library/Formula/cpp-netlib.rb
@@ -1,9 +1,9 @@
 class CppNetlib < Formula
   desc "C++ libraries for high level network programming"
   homepage "http://cpp-netlib.org"
-  url "http://downloads.cpp-netlib.org/0.11.2/cpp-netlib-0.11.2-final.tar.gz"
-  version "0.11.2"
-  sha256 "71953379c5a6fab618cbda9ac6639d87b35cab0600a4450a7392bc08c930f2b1"
+  url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-rc2.tar.gz"
+  version "0.12.0-rc2"
+  sha256 "a3342a068f7eb5bb8f83a9e3de91e4e62313a8cd443881cdc25c9163c6f3a213"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,15 +13,7 @@ class CppNetlib < Formula
     sha256 "093cc615abf08eeb6d698d85e9d4bb8003e536548f925246d86baa7f1ec45506" => :mountain_lion
   end
 
-  devel do
-    url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-rc1.tar.gz"
-    version "0.12.0-rc1"
-    sha256 "f692253c57219b52397a886af769afe207e9cf2eda8ad22ed0e9e48bb483fc03"
-
-    # Version 0.12.0+ moves from boost::asio to asio.
-    depends_on "asio"
-  end
-
+  depends_on "asio"
   depends_on "cmake" => :build
   depends_on "openssl"
 


### PR DESCRIPTION
Required by osquery 1.7.2 (Cf. facebook/osquery#1920)