### PR TITLE
citus 5.0.1 (new formula)

### DIFF
--- a/Library/Formula/citus.rb
+++ b/Library/Formula/citus.rb
@@ -9,14 +9,15 @@ class Citus < Formula
   depends_on "postgresql"
 
   def install
-    config_args = %W[--prefix=#{prefix} PG_CONFIG=#{Formula["postgresql"].opt_bin}/pg_config]
+    ENV["PG_CONFIG"] = Formula["postgresql"].opt_bin/"pg_config"
+
+    system "./configure"
 
     # workaround for https://github.com/Homebrew/homebrew/issues/49948
-    make_args = ["libpq=-L#{Formula["postgresql"].opt_lib} -lpq"]
+    system "make", "libpq=-L#{Formula["postgresql"].opt_lib} -lpq"
 
-    system "./configure", *config_args
-    system "make", *make_args
-
+    # Use stage directory to prevent installing to pg_config-defined dirs,
+    # which would not be within this package's Cellar.
     mkdir "stage"
     system "make", "install", "DESTDIR=#{buildpath}/stage"
 

--- a/Library/Formula/citus.rb
+++ b/Library/Formula/citus.rb
@@ -1,8 +1,8 @@
 class Citus < Formula
   desc "PostgreSQL-based distributed RDBMS"
   homepage "https://www.citusdata.com"
-  url "https://github.com/citusdata/citus/archive/v5.0.0.tar.gz"
-  sha256 "a72bd7e9020c11f19d08e58f1f8aa8e83e7f1f377facb6c8020fcaa917f9a3ee"
+  url "https://github.com/citusdata/citus/archive/v5.0.1.tar.gz"
+  sha256 "dd81a2f2a0fb5bb6e4a990b96f04857d7e6d8fcd607d7aabf70087506f7a2fc9"
 
   head "https://github.com/citusdata/citus.git"
 

--- a/Library/Formula/citus.rb
+++ b/Library/Formula/citus.rb
@@ -1,0 +1,55 @@
+class Citus < Formula
+  desc "PostgreSQL-based distributed RDBMS"
+  homepage "https://www.citusdata.com"
+  url "https://github.com/citusdata/citus/archive/v5.0.0.tar.gz"
+  sha256 "a72bd7e9020c11f19d08e58f1f8aa8e83e7f1f377facb6c8020fcaa917f9a3ee"
+
+  head "https://github.com/citusdata/citus.git"
+
+  depends_on "postgresql"
+
+  def install
+    config_args = %W[--prefix=#{prefix} PG_CONFIG=#{Formula["postgresql"].opt_bin}/pg_config]
+
+    # workaround for https://github.com/Homebrew/homebrew/issues/49948
+    make_args = ["libpq=-L#{Formula["postgresql"].opt_lib} -lpq"]
+
+    system "./configure", *config_args
+    system "make", *make_args
+
+    mkdir "stage"
+    system "make", "install", "DESTDIR=#{buildpath}/stage"
+
+    bin.install Dir["stage/**/bin/*"]
+    lib.install Dir["stage/**/lib/*"]
+    include.install Dir["stage/**/include/*"]
+    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
+  end
+
+  test do
+    pg_bin = Formula["postgresql"].opt_bin
+    pg_port = "55561"
+    system "#{pg_bin}/initdb", testpath/"test"
+    pid = fork do
+      exec("#{pg_bin}/postgres",
+           "-D", testpath/"test",
+           "-c", "shared_preload_libraries=citus",
+           "-p", pg_port)
+    end
+
+    begin
+      sleep 2
+
+      count_workers_query = "SELECT COUNT(*) FROM master_get_active_worker_nodes();"
+
+      system "#{pg_bin}/createdb", "-p", pg_port, "test"
+      system "#{pg_bin}/psql", "-p", pg_port, "-d", "test", "--command", "CREATE EXTENSION citus;"
+
+      assert_equal "0", shell_output("#{pg_bin}/psql -p #{pg_port} -d test -Atc" \
+                                     "'#{count_workers_query}'").strip
+    ensure
+      Process.kill 9, pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
Today Citus Data announced they "unforked" their PostgreSQL-based distributed database and open-sourced the whole project. This means Citus, previously a private fork of the PostgreSQL codebase, can now be added to an existing PostgreSQL install using the standard PostgreSQL CREATE EXTENSION command.

This is analogous to e.g. PostGIS, whose formula was used as an example when writing the formula for Citus. Other PostgreSQL-related formula provided good examples of a test block that actually starts PostgreSQL and verifies installation of the extension.

## Code Review Tasks

  - [x] Set `pg_config` using environment variable
  - [x] Move `make` and `configure` args inline to the relevant `system` calls
  - [x] Bump to latest Citus version (v5.0.1)
  - [x] Investigate installing directly to Cellar
  - [x] Move to new Homebrew repo and close this issue
