### PR TITLE
superenv: filter -I/-L paths on dependencies

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -14,8 +14,8 @@ require "pathname"
 require "set"
 
 class Cmd
-  attr_reader :config, :prefix, :cellar, :tmpdir, :sysroot
-  attr_reader :archflags, :optflags
+  attr_reader :config, :prefix, :cellar, :opt, :tmpdir, :sysroot, :deps
+  attr_reader :archflags, :optflags, :keg_regex
 
   def initialize(arg0, args)
     @arg0 = arg0
@@ -23,10 +23,14 @@ class Cmd
     @config = ENV.fetch("HOMEBREW_CCCFG") { "" }
     @prefix = ENV["HOMEBREW_PREFIX"]
     @cellar = ENV["HOMEBREW_CELLAR"]
+    @opt = ENV["HOMEBREW_OPT"]
     @tmpdir = ENV["HOMEBREW_TEMP"]
     @sysroot = ENV["HOMEBREW_SDKROOT"]
     @archflags = ENV.fetch("HOMEBREW_ARCHFLAGS") { "" }.split(" ")
     @optflags = ENV.fetch("HOMEBREW_OPTFLAGS") { "" }.split(" ")
+    @deps = Set.new(ENV.fetch("HOMEBREW_DEPENDENCIES") { "" }.split(","))
+    # matches opt or cellar prefix and formula name
+    @keg_regex = %r[(#{Regexp.escape(opt)}|#{Regexp.escape(cellar)})/([\w\-_\+]+)]
   end
 
   def mode
@@ -197,7 +201,16 @@ class Cmd
   end
 
   def keep?(path)
-    path.start_with?(prefix, cellar, tmpdir) || !path.start_with?("/opt", "/sw", "/usr/X11")
+    # first two paths: reject references to Cellar or opt paths
+    # for unspecified dependencies
+    if path.start_with?(cellar) || path.start_with?(opt)
+      dep = path[keg_regex, 2]
+      dep && @deps.include?(dep)
+    elsif path.start_with?(prefix)
+      true
+    else
+      !path.start_with?("/opt", "/sw", "/usr/X11")
+    end
   end
 
   def cflags

--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -201,6 +201,10 @@ class Cmd
   end
 
   def keep?(path)
+    # The logic in this method will eventually become the default,
+    # but is currently opt-in.
+    return keep_orig?(path) unless ENV["HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS"]
+
     # first two paths: reject references to Cellar or opt paths
     # for unspecified dependencies
     if path.start_with?(cellar) || path.start_with?(opt)
@@ -211,6 +215,11 @@ class Cmd
     else
       !path.start_with?("/opt", "/sw", "/usr/X11")
     end
+  end
+
+  # The original less-smart version of keep_orig; will eventually be removed
+  def keep_orig?(path)
+    path.start_with?(prefix, cellar, tmpdir) || !path.start_with?("/opt", "/sw", "/usr/X11")
   end
 
   def cflags

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -839,6 +839,7 @@ module Homebrew
     ENV["HOMEBREW_SANDBOX"] = "1"
     ENV["HOMEBREW_NO_EMOJI"] = "1"
     ENV["HOMEBREW_FAIL_LOG_LINES"] = "150"
+    ENV["HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS"] = "1"
 
     if ENV["TRAVIS"]
       ARGV << "--verbose"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -53,6 +53,7 @@ module Superenv
     self["HOMEBREW_BREW_FILE"] = HOMEBREW_BREW_FILE.to_s
     self["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX.to_s
     self["HOMEBREW_CELLAR"] = HOMEBREW_CELLAR.to_s
+    self["HOMEBREW_OPT"] = "#{HOMEBREW_PREFIX}/opt"
     self["HOMEBREW_TEMP"] = HOMEBREW_TEMP.to_s
     self["HOMEBREW_SDKROOT"] = effective_sysroot
     self["HOMEBREW_OPTFLAGS"] = determine_optflags
@@ -66,6 +67,7 @@ module Superenv
     self["HOMEBREW_ISYSTEM_PATHS"] = determine_isystem_paths
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
+    self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
 
     if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)
       self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
@@ -182,6 +184,10 @@ module Superenv
     paths << MacOS::X11.lib.to_s if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries"
     paths.to_path_s
+  end
+
+  def determine_dependencies
+    deps.map {|d| d.name}.join(",")
   end
 
   def determine_cmake_prefix_path


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

### Changes to Homebrew's Core:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

Previously, superenv did not try to filter -I or -L flags based on the list of requested dependencies; as a result, buildsystems which opportunistically discover Homebrew-installed libraries were able to link against them even under superenv.

This adds a list of all requested dependencies to the superenv environment, and compares all -I and -L flags against those; any Cellar and opt paths found which resolve to unrequested dependencies are filtered out.

An example of something this fixes can be seen using the [`brew bundle exec` command](https://github.com/Homebrew/homebrew-bundle/pull/160), with [this test repository](https://github.com/mistydemeo/openssl-bundle-example). Eventmachine will opportunistically try to locate and link to a Homebrew-installed openssl by hardcoding the `-I/usr/local/opt/openssl/include` flag, and without this patch superenv will allow that to pass. With this patch, and with the openssl dependency removed from the Brewfile, `brew bundle exec -- bundle install --binstubs --path vendor/gems` will cause that to be filtered out, preventing eventmachine from locating the unrequested dependency.

I expect this to potentially break some things, most likely in users' taps, so it'll need some testing before merging.