### PR TITLE
Add opt-in Google Analytics.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -202,6 +202,8 @@ class FormulaInstaller
 
     oh1 "Installing #{Tty.green}#{formula.full_name}#{Tty.reset}" if show_header?
 
+    report_analytics_event("install", formula.full_name)
+
     @@attempted << formula
 
     if pour_bottle?(:warn => true)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -5,6 +5,7 @@ require "utils/inreplace"
 require "utils/popen"
 require "utils/fork"
 require "utils/git"
+require "utils/analytics"
 require "open-uri"
 
 class Tty

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -1,0 +1,54 @@
+
+def analytics_anonymous_prefix_and_os
+  @analytics_anonymous_prefix_and_os ||= begin
+    "#{OS_VERSION}, #{HOMEBREW_PREFIX.to_s.gsub(ENV["HOME"], "~")}"
+  end
+end
+
+def report_analytics(type, metadata={})
+  return unless ENV["HOMEBREW_ANALYTICS"]
+
+  metadata_args = metadata.map do |key, value|
+    ["-d", "#{key}=#{value}"] if key && value
+  end.compact.flatten
+
+  # Send analytics. Anonymise the IP address (aip=1) and don't send or store
+  # any personally identifiable information.
+  # https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+  # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+  system "curl", "https://www.google-analytics.com/collect", "-d", "v=1",
+    "--silent", "--max-time", "3", "--output", "/dev/null",
+    "--user-agent", "#{HOMEBREW_USER_AGENT}",
+    "-d", "tid=#{ENV["HOMEBREW_ANALYTICS_ID"]}",
+    "-d", "cid=#{ENV["HOMEBREW_ANALYTICS_USER_UUID"]}",
+    "-d", "aip=1",
+    "-d", "an=Homebrew",
+    "-d", "av=#{HOMEBREW_VERSION}",
+    "-d", "t=#{type}",
+    *metadata_args
+end
+
+def report_analytics_event(category, action, label=analytics_anonymous_prefix_and_os, value=nil)
+  report_analytics(:event, {
+    :ec => category,
+    :ea => action,
+    :el => label,
+    :ev => value,
+  })
+end
+
+def report_analytics_exception(exception, options={})
+  if exception.is_a? BuildError
+    report_analytics_event("BuildError", e.formula.full_name)
+  end
+
+  fatal = options.fetch(:fatal, true) ? "1" : "0"
+  report_analytics(:exception, {
+    :exd => exception.class.name,
+    :exf => fatal,
+  })
+end
+
+def report_analytics_screenview(screen_name)
+  report_analytics(:screenview, :cd => screen_name)
+end

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -130,14 +130,17 @@ rescue Interrupt => e
   $stderr.puts # seemingly a newline is typical
   exit 130
 rescue BuildError => e
+  report_analytics_exception(e)
   e.dump
   exit 1
 rescue RuntimeError, SystemCallError => e
+  report_analytics_exception(e)
   raise if e.message.empty?
   onoe e
   $stderr.puts e.backtrace if ARGV.debug?
   exit 1
 rescue Exception => e
+  report_analytics_exception(e)
   onoe e
   if internal_cmd
     $stderr.puts "#{Tty.white}Please report this bug:"

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -1,4 +1,5 @@
 HOMEBREW_VERSION="0.9.8"
+HOMEBREW_USER_AGENT="Homebrew $HOMEBREW_VERSION"
 
 odie() {
   if [[ -t 2 ]] # check whether stderr is a tty.
@@ -158,6 +159,39 @@ your own risk.
 EOS
       ;;
   esac
+fi
+
+if [[ -n "$HOMEBREW_ANALYTICS" ]]
+then
+  # User UUID file. Used for Homebrew user counting. Can be deleted and
+  # recreated with no adverse effect (beyond our user counts being inflated).
+  HOMEBREW_ANALYTICS_USER_UUID_FILE="$HOME/.homebrew_analytics_user_uuid"
+  if [[ -r "$HOMEBREW_ANALYTICS_USER_UUID_FILE" ]]
+  then
+    HOMEBREW_ANALYTICS_USER_UUID="$(cat "$HOMEBREW_ANALYTICS_USER_UUID_FILE")"
+  else
+    HOMEBREW_ANALYTICS_USER_UUID="$(uuidgen)"
+    echo "$HOMEBREW_ANALYTICS_USER_UUID" > "$HOMEBREW_ANALYTICS_USER_UUID_FILE"
+  fi
+  export HOMEBREW_ANALYTICS_ID="UA-75654628-1"
+  export HOMEBREW_ANALYTICS_USER_UUID
+
+  # Send the to-be-executed command as an "App Screen View". Anonymise the IP
+  # address (aip=1) and don't send or store any personally identifiable
+  # information.
+  # https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#screenView
+  # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+  curl https://www.google-analytics.com/collect -d v=1 \
+    --silent --max-time 3 --output /dev/null \
+    --user-agent "$HOMEBREW_USER_AGENT" \
+    -d tid="$HOMEBREW_ANALYTICS_ID" \
+    -d cid="$HOMEBREW_ANALYTICS_USER_UUID" \
+    -d aip=1 \
+    -d an=Homebrew \
+    -d av="$HOMEBREW_VERSION" \
+    -d t=screenview \
+    -d cd="$HOMEBREW_COMMAND" \
+    &
 fi
 
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]


### PR DESCRIPTION
Add the first Google Analytics usage to monitor the command names that are run by Homebrew.

Don't freak out. I can give any maintainer who wants it (eventually you should all have it) access to the dashboard to see what personally identifiable information is (not) stored here. I've spent quite a while playing around with the API and settings and there's nothing to identify individual users. The "generate a UUID and allow it to be reset" is fairly standard in user tracking whilst allowing users to preserve anonymity.

Obviously as-is this isn't hugely useful beyond just seeing usage. Things I would want to do in future (probably in a rough order):
- Track `install` failures along with e.g. the options used to build and other useful but non-identifiable information
- Track exceptions that kill the application
- Flip analytics to be opt-out rather than opt-in; document and notify people on Twitter, IRC, the mailing list how to opt-out and show all the information sent and the level of detail we can('t) obtain for a given user