### PR TITLE
pan 0.140 (migrate from boneyard)

### DIFF
--- a/Library/Formula/pan.rb
+++ b/Library/Formula/pan.rb
@@ -1,0 +1,35 @@
+class Pan < Formula
+  desc "Usenet newsreader"
+  homepage "http://pan.rebelbase.com"
+  url "http://pan.rebelbase.com/download/releases/0.140/source/pan-0.140.tar.bz2"
+  sha256 "ba1c65ee75b9eca1f15f6249ea762492309731446edc8b09085b63ad34351c71"
+
+  depends_on "intltool" => :build
+  depends_on "gettext" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "gmime"
+  depends_on "gtk+3"
+  depends_on "gnome-icon-theme" => :recommended
+  depends_on "gnutls" => :optional
+  depends_on "gtkspell3" => :optional
+  depends_on "webkitgtk" => :optional
+
+  def install
+    ENV.append "LDFLAGS", "-liconv" # iconv detection is broken.
+    args = ["--disable-debug",
+            "--disable-dependency-tracking",
+            "--disable-silent-rules",
+            "--with-gtk3",
+            "--prefix=#{prefix}"]
+    args << "--with-gnutls" if build.with?("gnutls")
+    args << "--with-webkit" if build.with?("webkitgtk")
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/pan", "-h"
+  end
+end

--- a/Library/Homebrew/tap_migrations.rb
+++ b/Library/Homebrew/tap_migrations.rb
@@ -158,7 +158,6 @@ TAP_MIGRATIONS = {
   "opengrm-ngram" => "homebrew/science",
   "ori" => "homebrew/fuse",
   "p11-kit" => "homebrew/boneyard",
-  "pan" => "homebrew/boneyard",
   "paq8px" => "homebrew/boneyard",
   "par2tbb" => "homebrew/boneyard",
   "pari" => "homebrew/x11",


### PR DESCRIPTION
Hi, I have created a new formula for the pan newsreader. This formula was moved to the boneyard tap months ago because it failed to compile against clang, but it has been fixed upstream.

### All Submissions:

- [ X ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [ X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

_You can erase any parts of this template not applicable to your Pull Request._

### New Formulae Submissions:

- [ X ] Does your submission pass
`brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ X ] Have you built your formula locally prior to submission with `brew install <formula>`?


