### PR TITLE
git-multipush: audit fix - put 'head' before 'devel block'

### DIFF
--- a/Library/Formula/git-multipush.rb
+++ b/Library/Formula/git-multipush.rb
@@ -4,13 +4,13 @@ class GitMultipush < Formula
   url "https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2"
   sha256 "1f3b51e84310673045c3240048b44dd415a8a70568f365b6b48e7970afdafb67"
 
+  head "https://github.com/gavinbeatty/git-multipush.git"
+
   devel do
     url "https://github.com/gavinbeatty/git-multipush/archive/git-multipush-v2.4.rc2.tar.gz"
     sha256 "999d9304f322c1b97d150c96be64ecde30980f97eaaa9d66f365b8b11894c46d"
     version "2.4-rc2"
   end
-
-  head "https://github.com/gavinbeatty/git-multipush.git"
 
   depends_on "asciidoc" => :build
 


### PR DESCRIPTION
```brew audit --strict  git-multipush``` returns:

```
git-multipush:
 * `head` (line 13) should be put before `devel block` (line 7)
```

--

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

This PR fixes this warning.