### PR TITLE
lnav: Fix the '--with-curl' option

### DIFF
--- a/Library/Formula/lnav.rb
+++ b/Library/Formula/lnav.rb
@@ -23,10 +23,30 @@ class Lnav < Formula
   depends_on "curl" => ["with-libssh2", :optional]
 
   def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --with-readline=#{Formula["readline"].opt_prefix}
+    ]
+
+    if build.with? "curl"
+      # Specify the cURL binary path, so that the configure script
+      # can look up the correct compile time flags.
+      ENV.prepend_path "PATH", "#{Formula["curl"].bin}"
+
+      # cURL depends on libssh2, due to the 'with-libssh2' flag, which in turn
+      # depends on libcrypto and libssl. These are neither specified by the
+      # lnav configure scripts, nor curl-config binary.
+      ENV.append "LIBS", "-lcrypto -lssl"
+
+      # OS X ships with libcurl by default, albeit without sftp support. If we
+      # want lnav to use the keg-only cURL formula that we specify as a
+      # dependency, we need to pass in the path.
+      args << "--with-libcurl=#{Formula["curl"].opt_prefix}"
+    end
+
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-readline=#{Formula["readline"].opt_prefix}"
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew/pulls) for the same update/change?

Currently the lnav builds when compiled with the '--with-curl' option
fails due to missing linker flags.

This closes tstack/lnav#301