### PR TITLE
Correct Homebrew/brew source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homebrew (Legacy)
 This repository has been deprecated and split into two repositories:
-- [Homebrew/brew](https://github.com/Homebrew/brew): the Homebrew package manager without any formulae/packages (i.e. the former contents of `Library/Formula`)
+- [Homebrew/brew](https://github.com/Homebrew/brew): the Homebrew package manager without any formulae/packages (i.e. the former contents of `Library/Homebrew`)
 - [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core): the formulae/packages (i.e. the former contents of `Library/Formula`) for the Homebrew package manager
 
 Please note: you don't need to move pull requests or issues over from this. We will handle all migrations.


### PR DESCRIPTION
The readme shows that both Homebrew/brew and Homebrew/homebrew-core were the former contents of the same directory. I believe that the former was actually the contents of Library/Homebrew.